### PR TITLE
Proof of Concept for FlashLoan

### DIFF
--- a/contracts/FlashLoan.sol
+++ b/contracts/FlashLoan.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./interface/IFrankencoin.sol";
+import "./interface/IReserve.sol";
+
+contract FlashLoan {
+    IFrankencoin public immutable zchf;
+    uint256 public constant FLASHLOAN_MAX = 1_000_000 ether;
+    uint256 public constant FLASHLOAN_FEEPPM = 1_000;
+
+    uint256 public cooldown;
+
+    // ---------------------------------------------------------------------------------------------------
+    // Mappings
+    mapping(address => uint256) public senderMinted;
+    mapping(address => uint256) public senderRepaid;
+    mapping(address => uint256) public senderFees;
+
+    // ---------------------------------------------------------------------------------------------------
+    // Events
+    event Denied(address indexed denier, string message);
+    event Minted(address indexed sender, uint256 amount);
+    event Repaid(address indexed behalfOf, uint256 amount, uint256 repay, uint256 fee);
+    
+    // ---------------------------------------------------------------------------------------------------
+    // Errors
+    error Cooldown();
+
+    // ---------------------------------------------------------------------------------------------------
+    // Modifier
+    modifier noCooldown() {
+        if (block.timestamp <= cooldown) revert Cooldown();
+        _;
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    constructor(address _zchf) {
+        zchf = IFrankencoin(_zchf);
+        cooldown = block.timestamp + 3 days;
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    function deny(address[] calldata helpers, string calldata message) external noCooldown {
+        IReserve(zchf.reserve()).checkQualified(msg.sender, helpers);
+        cooldown = type(uint256).max;
+        emit Denied(msg.sender, message);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    function _verify(address sender) internal view noCooldown {
+        uint256 total = senderMinted[sender] * (1_000_000 + FLASHLOAN_FEEPPM);
+        uint256 repaid = senderRepaid[sender] * 1_000_000;
+        uint256 fee = senderFees[sender] * 1_000_000;
+        require(repaid + fee >= total, "Not paid bacm");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    function takeLoan(uint256 amount, bytes calldata callData) public noCooldown {
+        _verify(msg.sender);
+
+        senderMinted[msg.sender] += amount;
+        zchf.mint(msg.sender, amount);
+        emit Minted(msg.sender, amount);
+
+        (bool success, ) = msg.sender.call(callData);
+        require(success, "Ext. call failed");
+        
+        _verify(msg.sender);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    function repayLoan(address behalfOf, uint256 amount) public noCooldown {
+        zchf.transferFrom(behalfOf, address(this), amount);
+
+        uint256 fee = amount * FLASHLOAN_FEEPPM / 1_000_000;
+        uint256 repay = amount - fee;
+
+        senderRepaid[behalfOf] += repay;
+        senderFees[behalfOf] += fee;
+
+        zchf.transferFrom(address(this), address(zchf.reserve()), fee);
+        emit Repaid(behalfOf, amount, repay, fee);
+    }
+}

--- a/contracts/FlashLoan.sol
+++ b/contracts/FlashLoan.sol
@@ -40,6 +40,9 @@ contract FlashLoan {
     constructor(address _zchf) {
         zchf = IFrankencoin(_zchf);
         cooldown = block.timestamp + 3 days;
+
+        zchf.transferFrom(msg.sender, address(this), 1000 ether);
+        zchf.suggestMinter(address(this), 3 days, 1000 ether, "FlashLoanV0");
     }
 
     // ---------------------------------------------------------------------------------------------------

--- a/contracts/FlashLoan.sol
+++ b/contracts/FlashLoan.sol
@@ -82,10 +82,7 @@ contract FlashLoan {
         // execute all
         for (uint256 i = 0; i < targets.length; i++) {
             (bool success, bytes memory returnData) = targets[i].delegatecall(calldatas[i]);
-            if (!success) {
-                string memory errorMsg = _revertMessage(returnData);
-                revert(errorMsg);
-            }
+            if (!success) revert(_revertMessage(returnData));
         }
         
         // verify after
@@ -94,10 +91,18 @@ contract FlashLoan {
 
     // revert message
     function _revertMessage(bytes memory returndata) internal pure returns (string memory) {
-        if (returndata.length < 68) return "Delegatecall failed silently";
-        assembly {
-            returndata := add(returndata, 0x04)
+        if (returndata.length < 4) return "Delegatecall failed silently";
+
+        if (returndata.length == 4) {
+            assembly {
+                returndata := mload(add(returndata, 0x20))
+            }
+        } else {
+            assembly {
+                returndata := add(returndata, 0x04)
+            }
         }
+
         return abi.decode(returndata, (string)); 
     }
 

--- a/contracts/test/FrankencoinDeployerTest.sol
+++ b/contracts/test/FrankencoinDeployerTest.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../Frankencoin.sol";
+import "../PositionFactory.sol";
+import "../MintingHub.sol";
+import "../interface/IReserve.sol";
+
+contract DeployerFrankencoin {
+    Frankencoin public zchf;
+    PositionFactory public factory;
+    MintingHub public mintingHub;
+    
+    constructor() {
+        zchf = new Frankencoin(1);
+        factory = new PositionFactory();
+        mintingHub = new MintingHub(address(zchf), address(factory));
+
+        zchf.initialize(msg.sender, "Developer");
+        zchf.initialize(address(this), "Deployer");
+        zchf.initialize(address(mintingHub), "MintingHub");
+    }
+
+    function init() public {
+        zchf.mint(msg.sender, 1_000_000 ether);
+        zchf.mint(address(this), 1_000_000 ether);
+        IReserve(zchf.reserve()).invest(1000 ether, 1000 ether);
+        IReserve(zchf.reserve()).invest(100000 ether, 1 ether);
+    }
+}


### PR DESCRIPTION
# Development Branch for Flashloan's
> This is just a "Proof of Concept" branch and further developments can/should be made before merging.

# The FlashLoan contract 

The FlashLoan contract in the Frankencoin ecosystem provides a mechanism for users to borrow and repay ZCHF tokens within the same transaction without collateral. This kind of mechanism could be needed in implementing a Roll-Over feature for Frankencoin positions.

# Impact for FPS holders

FPS holder would benefit, due to
- control over shutdown with veto power 
> function shutdown(address[] calldata helpers, string calldata message) external noCooldown {}

- control over limit, e.g.
> uint256 public constant FLASHLOAN_TOTALMAX = 10_000_000 ether;
> uint256 public constant FLASHLOAN_MAX = 1_000_000 ether;

- earn a fee, e.g. 0.1% which gets transferred directly to the reserve
> zchf.transferFrom(msg.sender, address(zchf.reserve()), fee); 

# For a Position Roll-Over, the FlashLoan contract would allow users to:

- Borrow the necessary amount of ZCHF to repay their existing position.
- Repay the flash loan with the newly minted ZCHF from the new position.
- ~~Open a new position with potentially different parameters. (maybe not due to ownable?)~~

This process enables users to seamlessly(!) transition from one position to another without needing to have additional funds on hand (if possible). It's particularly useful for adjusting position parameters or extending the position's duration without closing and reopening.

The FlashLoan contract's ability to execute multiple calls in a single transaction (via the takeLoan function) makes it well-suited for this complex operation, ensuring atomicity and reducing the risk of partial execution.

# For testing "delegatecall" is used 
To play around with rolling position with a "FlashLoan", is is used to test. This is not safe, because it can overwrite the storage of the flashloan contract.