### PR TITLE
contracts/equity: remove ineffectual assignment

### DIFF
--- a/contracts/Equity.sol
+++ b/contracts/Equity.sol
@@ -291,7 +291,6 @@ contract Equity is ERC20PermitLight, MathUtil, IReserve {
     function _reduceVotes(address target, uint256 amount) internal returns (uint256) {
         uint256 votesBefore = votes(target);
         if (amount >= votesBefore) {
-            amount = votesBefore;
             voteAnchor[target] = _anchorTime();
             return votesBefore;
         } else {


### PR DESCRIPTION
The variable `amount` is not used anymore after
the assignment, which thus remains ineffective
and can be removed.