### PR TITLE
fix: correct path to address index

### DIFF
--- a/helper/wallet.ts
+++ b/helper/wallet.ts
@@ -1,17 +1,27 @@
-import { ethers } from 'ethers';
+import { ethers } from "ethers";
 
 export function getChildFromSeed(seed: string, index: number) {
-	return ethers.Wallet.fromPhrase(seed).deriveChild(index);
+  return ethers.HDNodeWallet.fromPhrase(
+    seed,
+    undefined,
+    `m/44'/60'/0'/0/${index}`
+  );
 }
 
 export function getAddressFromChildIndex(seed: string, index: number): string {
-	return ethers.Wallet.fromPhrase(seed).deriveChild(index).address;
+  return getChildFromSeed(seed, index).address;
 }
 
-export function getPublicKeyFromChildIndex(seed: string, index: number): string {
-	return ethers.Wallet.fromPhrase(seed).deriveChild(index).publicKey;
+export function getPublicKeyFromChildIndex(
+  seed: string,
+  index: number
+): string {
+  return getChildFromSeed(seed, index).publicKey;
 }
 
-export function getPrivateKeyFromChildIndex(seed: string, index: number): string {
-	return ethers.Wallet.fromPhrase(seed).deriveChild(index).privateKey;
+export function getPrivateKeyFromChildIndex(
+  seed: string,
+  index: number
+): string {
+  return getChildFromSeed(seed, index).privateKey;
 }


### PR DESCRIPTION
Input from @konstantinullrich

ETH Derivation Path to `path: "m/44'/60'/0'/0/0"` for deployment scripts
Fixed in helper/wallet.ts getChildFromSeed()

(BIP-44 standard) 
