### PR TITLE
fix: adds payable to ccip message functions

### DIFF
--- a/contracts/erc20/CrossChainReference.sol
+++ b/contracts/erc20/CrossChainReference.sol
@@ -31,29 +31,29 @@ abstract contract CrossChainReference is CrossChainERC20 {
     }
 
     // transfer within the cross chain context
-    function transfer(uint64 targetChain, address recipient, uint256 amount, string calldata ref) public returns (bool) {
+    function transfer(uint64 targetChain, address recipient, uint256 amount, string calldata ref) public payable returns (bool) {
         return transfer(targetChain, _toReceiver(recipient), amount, "", ref);
     }
 
-    function transfer(uint64 targetChain, address recipient, uint256 amount, Client.EVMExtraArgsV2 calldata extraArgs, string calldata ref) public returns (bool) {
+    function transfer(uint64 targetChain, address recipient, uint256 amount, Client.EVMExtraArgsV2 calldata extraArgs, string calldata ref) public payable returns (bool) {
         return transfer(targetChain, _toReceiver(recipient), amount, Client._argsToBytes(extraArgs), ref);
     }
 
-    function transfer(uint64 targetChain, bytes memory recipient, uint256 amount, bytes memory extraArgs, string calldata ref) public returns (bool) {
+    function transfer(uint64 targetChain, bytes memory recipient, uint256 amount, bytes memory extraArgs, string calldata ref) public payable returns (bool) {
         _crossTransfer(targetChain, msg.sender, recipient, amount, extraArgs, ref);
         return true;
     }
 
     // cross transfer from
-    function transferFrom(uint64 targetChain, address owner, address recipient, uint256 amount, string calldata ref) public returns (bool) {
+    function transferFrom(uint64 targetChain, address owner, address recipient, uint256 amount, string calldata ref) public payable returns (bool) {
         return transferFrom(targetChain, owner, _toReceiver(recipient), amount, "", ref);
     }
 
-    function transferFrom(uint64 targetChain, address owner, address recipient, uint256 amount, Client.EVMExtraArgsV2 calldata extraArgs, string calldata ref) public returns (bool) {
+    function transferFrom(uint64 targetChain, address owner, address recipient, uint256 amount, Client.EVMExtraArgsV2 calldata extraArgs, string calldata ref) public payable returns (bool) {
         return transferFrom(targetChain, owner, _toReceiver(recipient), amount, Client._argsToBytes(extraArgs), ref);
     }
 
-    function transferFrom(uint64 targetChain, address owner, bytes memory recipient, uint256 amount, bytes memory extraArgs, string calldata ref) public returns (bool) {
+    function transferFrom(uint64 targetChain, address owner, bytes memory recipient, uint256 amount, bytes memory extraArgs, string calldata ref) public payable returns (bool) {
         _useAllowance(owner, msg.sender, amount);
         _crossTransfer(targetChain, owner, recipient, amount, extraArgs, ref);
         return true;

--- a/contracts/transfer/TransferReference.sol
+++ b/contracts/transfer/TransferReference.sol
@@ -39,35 +39,35 @@ contract TransferReference is CCIPSender {
     }
 
     // cross transfer
-    function crossTransfer(uint64 targetChain, address recipient, uint256 amount, string calldata ref) public returns (bool) {
+    function crossTransfer(uint64 targetChain, address recipient, uint256 amount, string calldata ref) public payable returns (bool) {
         _crossTransfer(targetChain, msg.sender, _toReceiver(recipient), amount, "", ref);
         return true;
     }
 
-    function crossTransfer(uint64 targetChain, address recipient, uint256 amount, Client.EVMExtraArgsV2 calldata extraArgs, string calldata ref) public returns (bool) {
+    function crossTransfer(uint64 targetChain, address recipient, uint256 amount, Client.EVMExtraArgsV2 calldata extraArgs, string calldata ref) public payable returns (bool) {
         _crossTransfer(targetChain, msg.sender, _toReceiver(recipient), amount, Client._argsToBytes(extraArgs), ref);
         return true;
     }
 
-    function crossTransfer(uint64 targetChain, bytes memory recipient, uint256 amount, bytes calldata extraArgs, string calldata ref) public returns (bool) {
+    function crossTransfer(uint64 targetChain, bytes memory recipient, uint256 amount, bytes calldata extraArgs, string calldata ref) public payable returns (bool) {
         _crossTransfer(targetChain, msg.sender, recipient, amount, extraArgs, ref);
         return true;
     }
 
     // cross transfer from
-    function crossTransferFrom(uint64 targetChain, address owner, address recipient, uint256 amount, string calldata ref) public returns (bool) {
+    function crossTransferFrom(uint64 targetChain, address owner, address recipient, uint256 amount, string calldata ref) public payable returns (bool) {
         if (zchf.allowance(owner, msg.sender) < INFINITY) revert InfiniteAllowanceRequired(owner, msg.sender);
         _crossTransfer(targetChain, owner, _toReceiver(recipient), amount, "", ref);
         return true;
     }
 
-    function crossTransferFrom(uint64 targetChain, address owner, address recipient, uint256 amount, Client.EVMExtraArgsV2 calldata extraArgs, string calldata ref) public returns (bool) {
+    function crossTransferFrom(uint64 targetChain, address owner, address recipient, uint256 amount, Client.EVMExtraArgsV2 calldata extraArgs, string calldata ref) public payable returns (bool) {
         if (zchf.allowance(owner, msg.sender) < INFINITY) revert InfiniteAllowanceRequired(owner, msg.sender);
         _crossTransfer(targetChain, owner, _toReceiver(recipient), amount, Client._argsToBytes(extraArgs), ref);
         return true;
     }
 
-    function crossTransferFrom(uint64 targetChain, address owner, bytes memory recipient, uint256 amount, bytes calldata extraArgs, string calldata ref) public returns (bool) {
+    function crossTransferFrom(uint64 targetChain, address owner, bytes memory recipient, uint256 amount, bytes calldata extraArgs, string calldata ref) public payable returns (bool) {
         if (zchf.allowance(owner, msg.sender) < INFINITY) revert InfiniteAllowanceRequired(owner, msg.sender);
         _crossTransfer(targetChain, owner, recipient, amount, extraArgs, ref);
         return true;


### PR DESCRIPTION
Adds missing `payable` flag to functions that invoke a CCIP message, so users can pay the CCIP fee in the chain native token.
Fixes #68 