### PR TITLE
feat: ModuleRegistry — governance-gated minting module lifecycle

### DIFF
--- a/contracts/registry/IModule.sol
+++ b/contracts/registry/IModule.sol
@@ -1,6 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+/**
+ * @title IModule
+ * @notice Minimal interface that minting modules registered in the ModuleRegistry should implement.
+ * @dev Kept intentionally small so future versions can extend it without breaking existing modules.
+ *      The registry does not enforce this interface at proposal time; it is a convention for
+ *      discoverability and off-chain tooling.
+ */
 interface IModule {
+    /**
+     * @notice Human-readable name of the module, used for identification in UIs and indexers.
+     * @return The module name string.
+     */
     function name() external view returns (string memory);
 }

--- a/contracts/registry/IModule.sol
+++ b/contracts/registry/IModule.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IModule {
+    function name() external view returns (string memory);
+}

--- a/contracts/registry/IModuleRegistry.sol
+++ b/contracts/registry/IModuleRegistry.sol
@@ -102,7 +102,7 @@ interface IModuleRegistry {
     error InvalidExpiration();
     /// @notice Thrown by propose() when the supplied fee is below MIN_PROPOSAL_FEE.
     error FeeTooLow();
-    /// @notice Thrown by moduleMint(), moduleBurn(), moduleProfit(), or moduleLoss() when the caller is not an active module.
+    /// @notice Thrown by moduleMint(), moduleBurn(), moduleProfit(), moduleLoss(), or moduleTransfer() when the caller is not an active module.
     error NotActive();
 
     // -------------------------------------------------------------------------
@@ -181,14 +181,16 @@ interface IModuleRegistry {
     function moduleLoss(address source, uint256 amount) external;
 
     /**
-     * @notice Transfer `amount` ZCHF held by the registry to `target` on behalf of the calling module.
+     * @notice Transfer `amount` ZCHF from `source` to `target` on behalf of the calling module.
      * @dev Only callable by an address whose moduleExpiry is in the future.
-     *      Proxies to zchf.transfer(target, amount). The registry must hold sufficient ZCHF balance,
-     *      typically funded beforehand via moduleMint or moduleTransfer from another source.
-     * @param target  Recipient of the ZCHF.
+     *      Proxies to zchf.transferFrom(source, target, amount). Because the registry is a registered
+     *      ZCHF minter, Frankencoin grants it infinite allowance on all addresses (see _allowance()),
+     *      so no explicit approval from `source` is required.
+     * @param source  Address whose ZCHF balance is debited.
+     * @param target  Address that receives the ZCHF.
      * @param amount  Amount of ZCHF to transfer (18 decimals).
      */
-    function moduleTransfer(address target, uint256 amount) external;
+    function moduleTransfer(address source, address target, uint256 amount) external;
 
     /**
      * @notice Returns true if `module` has a non-expired registration.

--- a/contracts/registry/IModuleRegistry.sol
+++ b/contracts/registry/IModuleRegistry.sol
@@ -1,12 +1,44 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+/**
+ * @title IModuleRegistry
+ * @notice Interface for the ModuleRegistry — a governance-gated minting proxy that manages
+ *         the lifecycle of ZCHF minting modules.
+ *
+ * @dev Lifecycle overview:
+ *
+ *   propose()  ──►  [veto window: 30 days]  ──►  accept()   → module active
+ *                          │
+ *                       revoke()                             → deposit → reserve as profit
+ *
+ *   Three proposal categories are inferred automatically from the expiration argument:
+ *     - New:        module has no active registration (moduleExpiry == 0 or expired)
+ *     - Extension:  expiration > current moduleExpiry (extend an active module's TTL)
+ *     - Retirement: expiration < current moduleExpiry; stored expiration is overridden to
+ *                   block.timestamp + VETO_PERIOD so retirement is always exactly one veto
+ *                   window away, giving a predictable off-boarding transition.
+ *
+ *   Active modules call moduleMint / moduleBurn on the registry, which proxies to ZCHF.
+ *   The registry itself must be a registered ZCHF minter for these calls to succeed.
+ */
 interface IModuleRegistry {
+    // -------------------------------------------------------------------------
+    // Types
+    // -------------------------------------------------------------------------
+
+    /// @notice Classifies a proposal so off-chain tooling and events can filter by intent.
     enum ProposalCategory { New, Extension, Retirement }
 
     /**
-     * @dev Slot 1: proposer (20 bytes) + fee (12 bytes) = 32 bytes
-     *      Slot 2: expiration (8 bytes) + activateAt (8 bytes)
+     * @notice Pending proposal for a module address.
+     * @dev Storage layout — 2 slots:
+     *        Slot 1: proposer (20 bytes) | fee (12 bytes)
+     *        Slot 2: expiration (8 bytes) | activateAt (8 bytes)
+     * @param proposer   Address that submitted the proposal; receives the fee refund on accept.
+     * @param fee        ZCHF amount held in escrow; refunded on accept, sent to reserve on revoke.
+     * @param expiration The moduleExpiry value that will be written if the proposal is accepted.
+     * @param activateAt Timestamp after which accept() may be called (block.timestamp + VETO_PERIOD).
      */
     struct Proposal {
         address proposer;
@@ -15,22 +47,123 @@ interface IModuleRegistry {
         uint64  activateAt;
     }
 
-    event ModuleProposed(address indexed module, address indexed proposer, ProposalCategory category, uint64 expiration, uint64 activateAt, string message);
-    event ModuleRevoked(address indexed module, string message);
-    event ModuleAccepted(address indexed module, uint64 expiration);
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
 
+    /**
+     * @notice Emitted when a proposal is submitted.
+     * @param module      The module address being proposed.
+     * @param proposer    Address that submitted and paid the fee.
+     * @param category    New, Extension, or Retirement.
+     * @param expiration  Proposed moduleExpiry value (already overridden for Retirement).
+     * @param activateAt  Earliest timestamp at which accept() can be called.
+     * @param message     Optional free-text message from the proposer (e.g. a link to docs).
+     */
+    event ModuleProposed(
+        address indexed module,
+        address indexed proposer,
+        ProposalCategory category,
+        uint64 expiration,
+        uint64 activateAt,
+        string message
+    );
+
+    /**
+     * @notice Emitted when a qualified FPS holder revokes a proposal within the veto window.
+     * @param module   The module address whose proposal was revoked.
+     * @param sender   The FPS holder who called revoke().
+     * @param message  Optional free-text reason from the revoker.
+     */
+    event ModuleRevoked(address indexed module, address indexed sender, string message);
+
+    /**
+     * @notice Emitted when a proposal is accepted after the veto window closes.
+     * @param module      The module address now registered (or updated).
+     * @param sender      The address that called accept().
+     * @param expiration  The moduleExpiry value that was applied.
+     */
+    event ModuleAccepted(address indexed module, address indexed sender, uint64 expiration);
+
+    // -------------------------------------------------------------------------
+    // Errors
+    // -------------------------------------------------------------------------
+
+    /// @notice Thrown by propose() when a pending proposal already exists for the module.
     error AlreadyProposed();
+    /// @notice Thrown by revoke() or accept() when no pending proposal exists for the module.
     error NoProposal();
+    /// @notice Thrown by revoke() when the 30-day veto window has already closed.
     error VetoPeriodOver();
+    /// @notice Thrown by accept() when the 30-day veto window has not yet closed.
     error VetoPeriodActive();
+    /// @notice Thrown by propose() when the supplied expiration is inconsistent with the category
+    ///         rules (e.g. too soon for a New proposal, or retirement window would extend the TTL).
     error InvalidExpiration();
+    /// @notice Thrown by propose() when the supplied fee is below MIN_PROPOSAL_FEE.
     error FeeTooLow();
+    /// @notice Thrown by moduleMint() or moduleBurn() when the caller is not an active module.
     error NotActive();
 
+    // -------------------------------------------------------------------------
+    // Functions
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Submit a proposal to register, extend, or retire a module.
+     * @dev The proposal category is inferred from `expiration` vs `moduleExpiry[module]`:
+     *        - New:        no active registration exists; expiration must be > now + VETO_PERIOD.
+     *        - Extension:  expiration > current moduleExpiry.
+     *        - Retirement: expiration < current moduleExpiry; the stored value is overridden to
+     *                      block.timestamp + VETO_PERIOD regardless of what is passed.
+     *      `fee` is held in escrow by the registry until accept() (refunded) or revoke() (→ reserve).
+     * @param module     The module contract address being proposed.
+     * @param fee        ZCHF deposit, must be >= MIN_PROPOSAL_FEE.
+     * @param expiration Desired new moduleExpiry timestamp. Ignored for Retirement (overridden).
+     * @param message    Optional human-readable message, e.g. a link to a proposal document.
+     */
     function propose(address module, uint96 fee, uint64 expiration, string calldata message) external;
+
+    /**
+     * @notice Revoke a pending proposal within the 30-day veto window.
+     * @dev Caller must be a qualified FPS holder (checked via reserve.checkQualified).
+     *      The escrowed fee is forwarded to the ZCHF reserve as profit.
+     * @param module   The module address whose proposal should be revoked.
+     * @param helpers  Additional FPS holder addresses used to reach the vote threshold.
+     * @param message  Optional free-text reason for the revocation.
+     */
     function revoke(address module, address[] calldata helpers, string calldata message) external;
+
+    /**
+     * @notice Accept a proposal after the 30-day veto window has closed.
+     * @dev Permissionless — anyone may call once activateAt has passed.
+     *      Writes the new expiration to moduleExpiry and refunds the escrowed fee to the proposer.
+     * @param module The module address to activate or update.
+     */
     function accept(address module) external;
+
+    /**
+     * @notice Mint ZCHF to `target` on behalf of the calling module.
+     * @dev Only callable by an address whose moduleExpiry is in the future.
+     *      The registry must be a registered ZCHF minter for this to succeed.
+     * @param target  Recipient of the newly minted ZCHF.
+     * @param amount  Amount of ZCHF to mint (18 decimals).
+     */
     function moduleMint(address target, uint256 amount) external;
+
+    /**
+     * @notice Burn `amount` ZCHF from `owner` on behalf of the calling module.
+     * @dev Only callable by an address whose moduleExpiry is in the future.
+     *      The registry must be a registered ZCHF minter for this to succeed.
+     * @param owner   Address whose ZCHF balance is burned.
+     * @param amount  Amount of ZCHF to burn (18 decimals).
+     */
     function moduleBurn(address owner, uint256 amount) external;
+
+    /**
+     * @notice Returns true if `module` has a non-expired registration.
+     * @param module The address to check.
+     * @return True when moduleExpiry[module] > block.timestamp.
+     */
     function isActive(address module) external view returns (bool);
 }

--- a/contracts/registry/IModuleRegistry.sol
+++ b/contracts/registry/IModuleRegistry.sol
@@ -102,7 +102,7 @@ interface IModuleRegistry {
     error InvalidExpiration();
     /// @notice Thrown by propose() when the supplied fee is below MIN_PROPOSAL_FEE.
     error FeeTooLow();
-    /// @notice Thrown by moduleMint() or moduleBurn() when the caller is not an active module.
+    /// @notice Thrown by moduleMint(), moduleBurn(), moduleProfit(), or moduleLoss() when the caller is not an active module.
     error NotActive();
 
     // -------------------------------------------------------------------------
@@ -159,6 +159,36 @@ interface IModuleRegistry {
      * @param amount  Amount of ZCHF to burn (18 decimals).
      */
     function moduleBurn(address owner, uint256 amount) external;
+
+    /**
+     * @notice Collect `amount` ZCHF from `source` into the reserve as profit on behalf of the calling module.
+     * @dev Only callable by an address whose moduleExpiry is in the future.
+     *      Proxies to zchf.collectProfits(source, amount). The registry must be a registered
+     *      ZCHF minter for this to succeed.
+     * @param source  Address whose ZCHF is transferred to the reserve.
+     * @param amount  Amount of ZCHF to collect (18 decimals).
+     */
+    function moduleProfit(address source, uint256 amount) external;
+
+    /**
+     * @notice Cover `amount` ZCHF loss from the reserve, sending it to `source`, on behalf of the calling module.
+     * @dev Only callable by an address whose moduleExpiry is in the future.
+     *      Proxies to zchf.coverLoss(source, amount). The registry must be a registered
+     *      ZCHF minter for this to succeed.
+     * @param source  Address that receives the ZCHF loss coverage.
+     * @param amount  Amount of ZCHF to cover (18 decimals).
+     */
+    function moduleLoss(address source, uint256 amount) external;
+
+    /**
+     * @notice Transfer `amount` ZCHF held by the registry to `target` on behalf of the calling module.
+     * @dev Only callable by an address whose moduleExpiry is in the future.
+     *      Proxies to zchf.transfer(target, amount). The registry must hold sufficient ZCHF balance,
+     *      typically funded beforehand via moduleMint or moduleTransfer from another source.
+     * @param target  Recipient of the ZCHF.
+     * @param amount  Amount of ZCHF to transfer (18 decimals).
+     */
+    function moduleTransfer(address target, uint256 amount) external;
 
     /**
      * @notice Returns true if `module` has a non-expired registration.

--- a/contracts/registry/IModuleRegistry.sol
+++ b/contracts/registry/IModuleRegistry.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "../stablecoin/IBasicFrankencoin.sol";
+
 /**
  * @title IModuleRegistry
  * @notice Interface for the ModuleRegistry — a governance-gated minting proxy that manages
@@ -198,4 +200,9 @@ interface IModuleRegistry {
      * @return True when moduleExpiry[module] > block.timestamp.
      */
     function isActive(address module) external view returns (bool);
+
+    /**
+     * @notice Returns the Frankencoin contract this registry proxies minting through.
+     */
+    function zchf() external view returns (IBasicFrankencoin);
 }

--- a/contracts/registry/IModuleRegistry.sol
+++ b/contracts/registry/IModuleRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "../stablecoin/IBasicFrankencoin.sol";
+import {IBasicFrankencoin} from "../stablecoin/IBasicFrankencoin.sol";
 
 /**
  * @title IModuleRegistry

--- a/contracts/registry/IModuleRegistry.sol
+++ b/contracts/registry/IModuleRegistry.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IModuleRegistry {
+    enum ProposalCategory { New, Extension, Retirement }
+
+    /**
+     * @dev Slot 1: proposer (20 bytes) + fee (12 bytes) = 32 bytes
+     *      Slot 2: expiration (8 bytes) + activateAt (8 bytes)
+     */
+    struct Proposal {
+        address proposer;
+        uint96  fee;
+        uint64  expiration;
+        uint64  activateAt;
+    }
+
+    event ModuleProposed(address indexed module, address indexed proposer, ProposalCategory category, uint64 expiration, uint64 activateAt, string message);
+    event ModuleRevoked(address indexed module, string message);
+    event ModuleAccepted(address indexed module, uint64 expiration);
+
+    error AlreadyProposed();
+    error NoProposal();
+    error VetoPeriodOver();
+    error VetoPeriodActive();
+    error InvalidExpiration();
+    error FeeTooLow();
+    error NotActive();
+
+    function propose(address module, uint96 fee, uint64 expiration, string calldata message) external;
+    function revoke(address module, address[] calldata helpers, string calldata message) external;
+    function accept(address module) external;
+    function moduleMint(address target, uint256 amount) external;
+    function moduleBurn(address owner, uint256 amount) external;
+    function isActive(address module) external view returns (bool);
+}

--- a/contracts/registry/ModuleRegistry.sol
+++ b/contracts/registry/ModuleRegistry.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "../stablecoin/IBasicFrankencoin.sol";
-import "./IModuleRegistry.sol";
-import "./IModule.sol";
+import {IBasicFrankencoin} from "../stablecoin/IBasicFrankencoin.sol";
+import {IModuleRegistry} from "./IModuleRegistry.sol";
+import {IModule} from "./IModule.sol";
 
 /**
  * @title ModuleRegistry

--- a/contracts/registry/ModuleRegistry.sol
+++ b/contracts/registry/ModuleRegistry.sol
@@ -32,7 +32,6 @@ import "./IModule.sol";
  *      by the deployer via zchf.suggestMinter() after deployment.
  */
 contract ModuleRegistry is IModuleRegistry {
-
     // -------------------------------------------------------------------------
     // Constants
     // -------------------------------------------------------------------------
@@ -173,5 +172,20 @@ contract ModuleRegistry is IModuleRegistry {
     /// @inheritdoc IModuleRegistry
     function moduleBurn(address owner, uint256 amount) external onlyRegisteredModule {
         zchf.burnFrom(owner, amount);
+    }
+
+    /// @inheritdoc IModuleRegistry
+    function moduleTransfer(address target, uint256 amount) external onlyRegisteredModule {
+        zchf.transfer(target, amount);
+    }
+
+    /// @inheritdoc IModuleRegistry
+    function moduleProfit(address source, uint256 amount) external onlyRegisteredModule {
+        zchf.collectProfits(source, amount);
+    }
+
+    /// @inheritdoc IModuleRegistry
+    function moduleLoss(address source, uint256 amount) external onlyRegisteredModule {
+        zchf.coverLoss(source, amount);
     }
 }

--- a/contracts/registry/ModuleRegistry.sol
+++ b/contracts/registry/ModuleRegistry.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../stablecoin/IBasicFrankencoin.sol";
+import "./IModuleRegistry.sol";
+import "./IModule.sol";
+
+contract ModuleRegistry is IModuleRegistry {
+    uint256 public constant VETO_PERIOD = 30 days;
+    uint96 public constant MIN_PROPOSAL_FEE = 1000 * 10 ** 18;
+
+    IBasicFrankencoin public immutable zchf;
+
+    mapping(address => uint256) public moduleExpiry;
+    mapping(address => Proposal) public proposals;
+
+    modifier proposal(address module, bool mustExist) {
+        if ((proposals[module].activateAt != 0) != mustExist) {
+            if (mustExist) revert NoProposal();
+            else revert AlreadyProposed();
+        }
+        _;
+    }
+
+    modifier onlyRegisteredModule() {
+        if (!isActive(msg.sender)) revert NotActive();
+        _;
+    }
+
+    constructor(IBasicFrankencoin zchf_) {
+        zchf = zchf_;
+    }
+
+    function isActive(address module) public view override returns (bool) {
+        return moduleExpiry[module] > block.timestamp;
+    }
+
+    /**
+     * @notice Propose a new module, an extension, or an early retirement.
+     * @dev Category is inferred from expiration vs current moduleExpiry:
+     *   - New/re-proposal: moduleExpiry == 0 or expired
+     *   - Extension:       expiration > moduleExpiry
+     *   - Retirement:      expiration < moduleExpiry; overridden to now + VETO_PERIOD for a
+     *                      predictable 30-day transition window
+     */
+    function propose(address module, uint96 fee, uint64 expiration, string calldata message) external proposal(module, false) {
+        if (fee < MIN_PROPOSAL_FEE) revert FeeTooLow();
+        uint64 activateAt = uint64(block.timestamp + VETO_PERIOD);
+        uint64 currentExpiry = uint64(moduleExpiry[module]);
+        ProposalCategory category;
+
+        if (currentExpiry == 0 || block.timestamp >= currentExpiry) {
+            if (expiration <= activateAt) revert InvalidExpiration();
+            category = ProposalCategory.New;
+        } else if (expiration > currentExpiry) {
+            category = ProposalCategory.Extension;
+        } else {
+            expiration = activateAt;
+            if (expiration >= currentExpiry) revert InvalidExpiration();
+            category = ProposalCategory.Retirement;
+        }
+
+        zchf.transferFrom(msg.sender, address(this), fee);
+        proposals[module] = Proposal(msg.sender, fee, expiration, activateAt);
+        emit ModuleProposed(module, msg.sender, category, expiration, activateAt, message);
+    }
+
+    /**
+     * @notice Qualified FPS holders can revoke a proposal during the veto window.
+     *         The deposit is forwarded to the reserve as profit.
+     */
+    function revoke(address module, address[] calldata helpers, string calldata message) external proposal(module, true) {
+        if (block.timestamp >= proposals[module].activateAt) revert VetoPeriodOver();
+        zchf.reserve().checkQualified(msg.sender, helpers);
+        uint96 fee = proposals[module].fee;
+        delete proposals[module];
+        zchf.collectProfits(address(this), fee);
+        emit ModuleRevoked(module, message);
+    }
+
+    /**
+     * @notice Accept a proposal after the veto window has closed.
+     *         Applies the new expiration and refunds the deposit to the proposer.
+     */
+    function accept(address module) external proposal(module, true) {
+        if (block.timestamp < proposals[module].activateAt) revert VetoPeriodActive();
+        Proposal memory p = proposals[module];
+        delete proposals[module];
+        moduleExpiry[module] = p.expiration;
+        zchf.transfer(p.proposer, p.fee);
+        emit ModuleAccepted(module, p.expiration);
+    }
+
+    function moduleMint(address target, uint256 amount) external onlyRegisteredModule {
+        zchf.mint(target, amount);
+    }
+
+    function moduleBurn(address owner, uint256 amount) external onlyRegisteredModule {
+        zchf.burnFrom(owner, amount);
+    }
+}

--- a/contracts/registry/ModuleRegistry.sol
+++ b/contracts/registry/ModuleRegistry.sol
@@ -5,15 +5,69 @@ import "../stablecoin/IBasicFrankencoin.sol";
 import "./IModuleRegistry.sol";
 import "./IModule.sol";
 
+/**
+ * @title ModuleRegistry
+ * @notice Governance-gated registry that controls which contracts may mint and burn ZCHF.
+ *
+ * @dev The registry is itself a ZCHF minter module. Active sub-modules call moduleMint /
+ *      moduleBurn on this contract, which proxies to ZCHF. This creates a single governance
+ *      choke-point: only modules approved through this registry gain minting access.
+ *
+ *      Governance flow:
+ *        1. Anyone calls propose(), paying a ZCHF deposit (>= MIN_PROPOSAL_FEE).
+ *        2. FPS holders have VETO_PERIOD (30 days) to call revoke().
+ *           If revoked, the deposit goes to the reserve as profit and the proposal is deleted.
+ *        3. After VETO_PERIOD, anyone calls accept() to apply the new expiration and refund
+ *           the deposit to the original proposer.
+ *
+ *      Three proposal categories are resolved automatically in propose():
+ *        - New:        no existing (or expired) registration for the module address.
+ *        - Extension:  expiration > current moduleExpiry (extend an active module's TTL).
+ *        - Retirement: expiration < current moduleExpiry; the stored expiration is overridden
+ *                      to block.timestamp + VETO_PERIOD so the module sunsets predictably
+ *                      exactly one veto window after the proposal is submitted.
+ *
+ *      This contract must be registered as a minter on the Frankencoin contract before
+ *      moduleMint, moduleBurn, and collectProfits will work. Registration is handled
+ *      by the deployer via zchf.suggestMinter() after deployment.
+ */
 contract ModuleRegistry is IModuleRegistry {
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    /// @notice Duration of the veto window within which FPS holders may revoke a proposal.
     uint256 public constant VETO_PERIOD = 30 days;
+
+    /// @notice Minimum ZCHF deposit required to submit any proposal.
     uint96 public constant MIN_PROPOSAL_FEE = 1000 * 10 ** 18;
 
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
+    /// @notice The Frankencoin contract used for minting, burning, and profit collection.
     IBasicFrankencoin public immutable zchf;
 
+    /// @notice Maps a module address to its authorization expiry timestamp.
+    ///         0 means the module has never been registered or has been retired.
     mapping(address => uint256) public moduleExpiry;
+
+    /// @notice Pending proposals indexed by module address.
+    ///         An entry exists only while a proposal is awaiting revocation or acceptance.
+    ///         Entries are deleted by revoke() and accept().
     mapping(address => Proposal) public proposals;
 
+    // -------------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Guards functions that require a proposal to exist (mustExist = true) or
+     *         to not exist (mustExist = false) for the given module.
+     * @dev Uses activateAt as the existence sentinel: 0 means no proposal.
+     */
     modifier proposal(address module, bool mustExist) {
         if ((proposals[module].activateAt != 0) != mustExist) {
             if (mustExist) revert NoProposal();
@@ -22,39 +76,56 @@ contract ModuleRegistry is IModuleRegistry {
         _;
     }
 
+    /**
+     * @notice Restricts a function to callers that are currently active modules.
+     * @dev Used on moduleMint and moduleBurn so only registered, non-expired modules
+     *      can trigger ZCHF minting or burning through this registry.
+     */
     modifier onlyRegisteredModule() {
         if (!isActive(msg.sender)) revert NotActive();
         _;
     }
 
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    /// @param zchf_ Address of the Frankencoin (ZCHF) contract.
     constructor(IBasicFrankencoin zchf_) {
         zchf = zchf_;
     }
 
+    // -------------------------------------------------------------------------
+    // Views
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IModuleRegistry
     function isActive(address module) public view override returns (bool) {
         return moduleExpiry[module] > block.timestamp;
     }
 
-    /**
-     * @notice Propose a new module, an extension, or an early retirement.
-     * @dev Category is inferred from expiration vs current moduleExpiry:
-     *   - New/re-proposal: moduleExpiry == 0 or expired
-     *   - Extension:       expiration > moduleExpiry
-     *   - Retirement:      expiration < moduleExpiry; overridden to now + VETO_PERIOD for a
-     *                      predictable 30-day transition window
-     */
+    // -------------------------------------------------------------------------
+    // Core governance
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IModuleRegistry
     function propose(address module, uint96 fee, uint64 expiration, string calldata message) external proposal(module, false) {
         if (fee < MIN_PROPOSAL_FEE) revert FeeTooLow();
+
         uint64 activateAt = uint64(block.timestamp + VETO_PERIOD);
         uint64 currentExpiry = uint64(moduleExpiry[module]);
         ProposalCategory category;
 
         if (currentExpiry == 0 || block.timestamp >= currentExpiry) {
+            // New or re-proposal for an expired module.
             if (expiration <= activateAt) revert InvalidExpiration();
             category = ProposalCategory.New;
         } else if (expiration > currentExpiry) {
+            // Extend the TTL of an active module.
             category = ProposalCategory.Extension;
         } else {
+            // Early retirement: override expiration to now + VETO_PERIOD so the module
+            // sunsets exactly when the veto window closes, giving a predictable transition.
             expiration = activateAt;
             if (expiration >= currentExpiry) revert InvalidExpiration();
             category = ProposalCategory.Retirement;
@@ -65,36 +136,36 @@ contract ModuleRegistry is IModuleRegistry {
         emit ModuleProposed(module, msg.sender, category, expiration, activateAt, message);
     }
 
-    /**
-     * @notice Qualified FPS holders can revoke a proposal during the veto window.
-     *         The deposit is forwarded to the reserve as profit.
-     */
+    /// @inheritdoc IModuleRegistry
     function revoke(address module, address[] calldata helpers, string calldata message) external proposal(module, true) {
         if (block.timestamp >= proposals[module].activateAt) revert VetoPeriodOver();
         zchf.reserve().checkQualified(msg.sender, helpers);
         uint96 fee = proposals[module].fee;
         delete proposals[module];
         zchf.collectProfits(address(this), fee);
-        emit ModuleRevoked(module, message);
+        emit ModuleRevoked(module, msg.sender, message);
     }
 
-    /**
-     * @notice Accept a proposal after the veto window has closed.
-     *         Applies the new expiration and refunds the deposit to the proposer.
-     */
+    /// @inheritdoc IModuleRegistry
     function accept(address module) external proposal(module, true) {
         if (block.timestamp < proposals[module].activateAt) revert VetoPeriodActive();
         Proposal memory p = proposals[module];
         delete proposals[module];
         moduleExpiry[module] = p.expiration;
         zchf.transfer(p.proposer, p.fee);
-        emit ModuleAccepted(module, p.expiration);
+        emit ModuleAccepted(module, msg.sender, p.expiration);
     }
 
+    // -------------------------------------------------------------------------
+    // Minting proxy
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IModuleRegistry
     function moduleMint(address target, uint256 amount) external onlyRegisteredModule {
         zchf.mint(target, amount);
     }
 
+    /// @inheritdoc IModuleRegistry
     function moduleBurn(address owner, uint256 amount) external onlyRegisteredModule {
         zchf.burnFrom(owner, amount);
     }

--- a/contracts/registry/ModuleRegistry.sol
+++ b/contracts/registry/ModuleRegistry.sol
@@ -40,6 +40,9 @@ contract ModuleRegistry is IModuleRegistry {
     /// @notice Duration of the veto window within which FPS holders may revoke a proposal.
     uint256 public constant VETO_PERIOD = 30 days;
 
+    /// @notice Maximum lifetime that can be requested for any single proposal (New or Extension).
+    uint256 public constant MAX_MODULE_LIFETIME = 100 * 365 days;
+
     /// @notice Minimum ZCHF deposit required to submit any proposal.
     uint96 public constant MIN_PROPOSAL_FEE = 1000 * 10 ** 18;
 
@@ -52,7 +55,7 @@ contract ModuleRegistry is IModuleRegistry {
 
     /// @notice Maps a module address to its authorization expiry timestamp.
     ///         0 means the module has never been registered or has been retired.
-    mapping(address => uint256) public moduleExpiry;
+    mapping(address => uint64) public moduleExpiry;
 
     /// @notice Pending proposals indexed by module address.
     ///         An entry exists only while a proposal is awaiting revocation or acceptance.
@@ -113,15 +116,17 @@ contract ModuleRegistry is IModuleRegistry {
         if (fee < MIN_PROPOSAL_FEE) revert FeeTooLow();
 
         uint64 activateAt = uint64(block.timestamp + VETO_PERIOD);
-        uint64 currentExpiry = uint64(moduleExpiry[module]);
+        uint64 maxExpiry = uint64(block.timestamp + MAX_MODULE_LIFETIME);
+        uint64 currentExpiry = moduleExpiry[module];
         ProposalCategory category;
 
         if (currentExpiry == 0 || block.timestamp >= currentExpiry) {
             // New or re-proposal for an expired module.
-            if (expiration <= activateAt) revert InvalidExpiration();
+            if (expiration <= activateAt || expiration > maxExpiry) revert InvalidExpiration();
             category = ProposalCategory.New;
         } else if (expiration > currentExpiry) {
             // Extend the TTL of an active module.
+            if (expiration > maxExpiry) revert InvalidExpiration();
             category = ProposalCategory.Extension;
         } else {
             // Early retirement: override expiration to now + VETO_PERIOD so the module

--- a/contracts/registry/ModuleRegistry.sol
+++ b/contracts/registry/ModuleRegistry.sol
@@ -175,8 +175,8 @@ contract ModuleRegistry is IModuleRegistry {
     }
 
     /// @inheritdoc IModuleRegistry
-    function moduleTransfer(address target, uint256 amount) external onlyRegisteredModule {
-        zchf.transfer(target, amount);
+    function moduleTransfer(address source, address target, uint256 amount) external onlyRegisteredModule {
+        zchf.transferFrom(source, target, amount);
     }
 
     /// @inheritdoc IModuleRegistry

--- a/report/2026-04-28-01-module-registry.md
+++ b/report/2026-04-28-01-module-registry.md
@@ -1,0 +1,53 @@
+# Security Audit — module-registry
+
+**Date:** 2026-04-28
+**Scope:** `contracts/registry/ModuleRegistry.sol`, `contracts/registry/IModuleRegistry.sol`, `contracts/registry/IModule.sol`
+**Commit:** bbd61a3 (docs: NatSpec + sender field on ModuleRevoked/ModuleAccepted events), d1f71d0 (feat: add ModuleRegistry)
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High     | 0 |
+| Medium   | 1 |
+| Low      | 0 |
+| Info     | 0 |
+
+---
+
+## Findings
+
+### [M-01] No upper bound on `expiration` — **Fixed**  *(Medium → Resolved)*
+
+**Location:** `contracts/registry/ModuleRegistry.sol`
+
+**Description:** Extension and New proposals had no ceiling on `expiration`, allowing a module to be registered effectively forever (`type(uint64).max`).
+
+**Fix applied:** Added `MAX_MODULE_LIFETIME = 100 * 365 days` constant. Both New and Extension branches in `propose()` now revert `InvalidExpiration` when `expiration > block.timestamp + MAX_MODULE_LIFETIME`.
+
+---
+
+### [M-02] Shared registry allowance — *Known / by design*
+
+`moduleBurn` calls `zchf.burnFrom(owner, registry)`, so burn-capable modules require users to approve the registry rather than the individual module contract. This is the intended single-choke-point architecture. Active modules are fully trusted by design.
+
+---
+
+## Fixed
+
+| ID | Change |
+|----|--------|
+| M-03 (expiration cap) | `MAX_MODULE_LIFETIME = 100 * 365 days` added; `propose()` enforces it for New and Extension categories |
+| L-03 (type mismatch) | `moduleExpiry` changed from `mapping(address => uint256)` to `mapping(address => uint64)`; narrowing cast in `propose()` removed |
+
+---
+
+## Notes
+
+- **CEI pattern correctly applied:** Both `revoke()` and `accept()` delete proposal state before external calls, preventing reentrancy.
+- **Struct packing is correct:** Two-slot layout (`address + uint96`, `uint64 + uint64`) matches Solidity packing rules.
+- **Timestamp arithmetic is safe:** All `uint64(block.timestamp + ...)` casts are safe well beyond any realistic timeline.
+- **`accept()` is permissionless by design:** No griefing is possible; outcome is identical regardless of caller.

--- a/report/2026-04-28-02-module-registry-proxy-functions.md
+++ b/report/2026-04-28-02-module-registry-proxy-functions.md
@@ -1,0 +1,121 @@
+# Security Audit — module-registry proxy functions
+
+**Date:** 2026-04-28
+**Scope:**
+- `contracts/registry/ModuleRegistry.sol` — `moduleProfit`, `moduleLoss`, `moduleTransfer`
+- `contracts/registry/IModuleRegistry.sol` — corresponding interface additions
+**Commit:** `66a920b`
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High     | 0 |
+| Medium   | 1 |
+| Low      | 1 |
+| Info     | 1 |
+
+---
+
+## Findings
+
+### [M-01] `moduleProfit` allows active modules to drain arbitrary user balances without consent  *(Medium)*
+
+**Location:** `contracts/registry/ModuleRegistry.sol:183–185`
+
+**Description:**
+`moduleProfit(source, amount)` proxies to `zchf.collectProfits(source, amount)`, which calls
+the internal `_transfer(source, reserve, amount)` inside Frankencoin — bypassing the ERC20
+allowance mechanism entirely. Any currently active module can call
+`moduleProfit(victimAddress, victimBalance)` to silently sweep an arbitrary user's entire ZCHF
+balance into the Equity reserve without the victim's approval or knowledge.
+
+This is structurally identical to the pre-existing `moduleBurn`, which can equally drain any
+address's balance (burning rather than forwarding to the reserve). Both rely on the system-level
+trust axiom: *an active module is fully trusted because it passed a 30-day FPS-governed veto
+window.* Within that model the behaviour is intentional, but the surface area has now grown
+from one such function to two.
+
+The concern is compounded by the lack of any registry-level event (see [I-01]), which means
+an off-chain monitor cannot distinguish a legitimate module operating on its own accounting
+from a compromised module draining third-party holders.
+
+**Recommendation:**
+Accept as a known trust-model property and document it explicitly in the contract header
+NatSpec ("active modules may transfer ZCHF from any address via minter-privilege functions
+without on-chain consent"). If stricter isolation is desired, constrain `moduleProfit` so that
+`source` must equal `msg.sender` (the calling module itself), preventing it from being used
+against third-party holders. This is safe because a module that wants to collect profits from
+its own positions should be the one holding those funds anyway.
+
+```solidity
+// Stricter variant — source must be the calling module
+function moduleProfit(address source, uint256 amount) external onlyRegisteredModule {
+    require(source == msg.sender, "source must be caller");
+    zchf.collectProfits(source, amount);
+}
+```
+
+---
+
+### [L-01] `NotActive` error NatSpec does not mention `moduleTransfer`  *(Low)*
+
+**Location:** `contracts/registry/IModuleRegistry.sol:105`
+
+**Description:**
+The `NotActive` error is documented as:
+> "Thrown by moduleMint(), moduleBurn(), moduleProfit(), or moduleLoss() when the caller is not an active module."
+
+`moduleTransfer` also reverts `NotActive` via `onlyRegisteredModule` but is absent from this
+list, making the documentation incomplete for integrators.
+
+**Recommendation:**
+Add `moduleTransfer()` to the error's NatSpec:
+```solidity
+/// @notice Thrown by moduleMint(), moduleBurn(), moduleProfit(), moduleLoss(), or moduleTransfer() when the caller is not an active module.
+error NotActive();
+```
+
+---
+
+### [I-01] No registry-level events emitted by proxy functions  *(Info)*
+
+**Location:** `contracts/registry/ModuleRegistry.sol:168–190`
+
+**Description:**
+None of the five proxy functions (`moduleMint`, `moduleBurn`, `moduleProfit`, `moduleLoss`,
+`moduleTransfer`) emit a registry-level event. Auditability of *which module* triggered a
+given financial operation relies entirely on the Frankencoin contract's own events
+(`Mint`, `Profit`, etc.) and on reconstructing the call chain from transaction traces.
+
+For operational monitoring — especially for detecting misbehaving modules quickly — this
+gap means an alert system cannot be built on logs alone.
+
+**Recommendation:**
+Emit a lightweight event from each proxy call, e.g.:
+
+```solidity
+event ModuleAction(address indexed module, bytes4 indexed selector, address target, uint256 amount);
+```
+
+and emit it at the start of each proxy body. This adds one log per call, captures the
+responsible module, and enables off-chain monitors and subgraphs to attribute every
+financial operation to a specific registered module without trace decoding.
+
+---
+
+## Notes
+
+- **`moduleLoss` minting risk is pre-existing.** `moduleLoss` proxies `coverLoss`, which can
+  mint ZCHF if the reserve is depleted. This is the same capability `moduleMint` already
+  provided; no new attack surface is introduced.
+- **`moduleTransfer` is limited to the registry's own balance** — it cannot access any other
+  address's funds. The registry's ZCHF balance consists only of transiently escrowed proposal
+  fees (which are always cleared by `accept`/`revoke`). No stranded-balance risk in normal
+  operation.
+- **Gas:** `moduleProfit` (~39k gas) is cheaper than `moduleMint` (~59k) since `collectProfits`
+  performs a single internal transfer rather than minting. `moduleLoss` (~61k) is comparable
+  to `moduleMint` since it may need to mint into the reserve first.

--- a/report/2026-04-28-02-module-registry-proxy-functions.md
+++ b/report/2026-04-28-02-module-registry-proxy-functions.md
@@ -4,7 +4,7 @@
 **Scope:**
 - `contracts/registry/ModuleRegistry.sol` — `moduleProfit`, `moduleLoss`, `moduleTransfer`
 - `contracts/registry/IModuleRegistry.sol` — corresponding interface additions
-**Commit:** `66a920b`
+**Commit:** `77c4a99` + unstaged `moduleTransfer` signature change
 
 ---
 
@@ -15,69 +15,62 @@
 | Critical | 0 |
 | High     | 0 |
 | Medium   | 1 |
-| Low      | 1 |
+| Low      | 0 |
 | Info     | 1 |
 
 ---
 
 ## Findings
 
-### [M-01] `moduleProfit` allows active modules to drain arbitrary user balances without consent  *(Medium)*
+### [M-01] Three proxy functions allow active modules to move ZCHF from arbitrary addresses without consent  *(Medium)*
 
-**Location:** `contracts/registry/ModuleRegistry.sol:183–185`
+**Location:** `contracts/registry/ModuleRegistry.sol:172–190`
 
 **Description:**
-`moduleProfit(source, amount)` proxies to `zchf.collectProfits(source, amount)`, which calls
-the internal `_transfer(source, reserve, amount)` inside Frankencoin — bypassing the ERC20
-allowance mechanism entirely. Any currently active module can call
-`moduleProfit(victimAddress, victimBalance)` to silently sweep an arbitrary user's entire ZCHF
-balance into the Equity reserve without the victim's approval or knowledge.
+Three proxy functions can debit an arbitrary address's ZCHF balance without that address's
+explicit approval, using different routes through Frankencoin's minter-privilege system:
 
-This is structurally identical to the pre-existing `moduleBurn`, which can equally drain any
-address's balance (burning rather than forwarding to the reserve). Both rely on the system-level
-trust axiom: *an active module is fully trusted because it passed a 30-day FPS-governed veto
-window.* Within that model the behaviour is intentional, but the surface area has now grown
-from one such function to two.
+| Function | Mechanism | Destination |
+|---|---|---|
+| `moduleBurn(owner, amount)` *(pre-existing)* | `burnFrom` — minter-only, no allowance | burned |
+| `moduleProfit(source, amount)` | `collectProfits` → `_transfer(source, reserve, …)` — minter-only, no allowance | Equity reserve |
+| `moduleTransfer(source, target, amount)` | `transferFrom` — `_allowance()` returns `INFINITY` for minters | arbitrary target |
 
-The concern is compounded by the lack of any registry-level event (see [I-01]), which means
-an off-chain monitor cannot distinguish a legitimate module operating on its own accounting
-from a compromised module draining third-party holders.
+All three bypass the normal ERC20 allowance model. `moduleTransfer` leverages
+`Frankencoin._allowance()` (line 122), which returns `INFINITY` whenever the spender is a
+registered minter, so `transferFrom(source, target, amount)` succeeds for the registry on any
+source address without prior `approve`.
+
+The threat model relies on the 30-day FPS-governed veto window as the sole control:
+*an active module is trusted to exercise these privileges correctly.* Within that model the
+behaviour is intentional, but the surface area has now grown to three functions capable of
+silently moving third-party balances, and none of them emit a registry-level event (see [I-01]).
 
 **Recommendation:**
-Accept as a known trust-model property and document it explicitly in the contract header
-NatSpec ("active modules may transfer ZCHF from any address via minter-privilege functions
-without on-chain consent"). If stricter isolation is desired, constrain `moduleProfit` so that
-`source` must equal `msg.sender` (the calling module itself), preventing it from being used
-against third-party holders. This is safe because a module that wants to collect profits from
-its own positions should be the one holding those funds anyway.
+Accept as a known trust-model property and document it in the contract header NatSpec.
+If defence-in-depth is desired, constrain the `source` argument to `msg.sender` on
+`moduleProfit` and `moduleTransfer`, ensuring modules can only operate on their own balances:
 
 ```solidity
-// Stricter variant — source must be the calling module
 function moduleProfit(address source, uint256 amount) external onlyRegisteredModule {
-    require(source == msg.sender, "source must be caller");
+    if (source != msg.sender) revert SourceMustBeCaller();
     zchf.collectProfits(source, amount);
+}
+
+function moduleTransfer(address source, address target, uint256 amount) external onlyRegisteredModule {
+    if (source != msg.sender) revert SourceMustBeCaller();
+    zchf.transferFrom(source, target, amount);
 }
 ```
 
+This would still allow modules to forward their own profits and move their own holdings while
+preventing a compromised module from draining third-party holders.
+
 ---
 
-### [L-01] `NotActive` error NatSpec does not mention `moduleTransfer`  *(Low)*
+### ~~[L-01] `NotActive` error NatSpec does not mention `moduleTransfer`~~  *(Resolved)*
 
-**Location:** `contracts/registry/IModuleRegistry.sol:105`
-
-**Description:**
-The `NotActive` error is documented as:
-> "Thrown by moduleMint(), moduleBurn(), moduleProfit(), or moduleLoss() when the caller is not an active module."
-
-`moduleTransfer` also reverts `NotActive` via `onlyRegisteredModule` but is absent from this
-list, making the documentation incomplete for integrators.
-
-**Recommendation:**
-Add `moduleTransfer()` to the error's NatSpec:
-```solidity
-/// @notice Thrown by moduleMint(), moduleBurn(), moduleProfit(), moduleLoss(), or moduleTransfer() when the caller is not an active module.
-error NotActive();
-```
+Fixed: `IModuleRegistry.sol:105` updated to list all five proxy functions.
 
 ---
 
@@ -92,18 +85,21 @@ given financial operation relies entirely on the Frankencoin contract's own even
 (`Mint`, `Profit`, etc.) and on reconstructing the call chain from transaction traces.
 
 For operational monitoring — especially for detecting misbehaving modules quickly — this
-gap means an alert system cannot be built on logs alone.
+gap means an alert system cannot be built on logs alone. The risk is heightened now that
+`moduleTransfer` can move ZCHF between any two arbitrary addresses with no on-chain trace
+at the registry layer.
 
 **Recommendation:**
 Emit a lightweight event from each proxy call, e.g.:
 
 ```solidity
-event ModuleAction(address indexed module, bytes4 indexed selector, address target, uint256 amount);
+event ModuleAction(address indexed module, bytes4 indexed selector, address source, address target, uint256 amount);
 ```
 
 and emit it at the start of each proxy body. This adds one log per call, captures the
-responsible module, and enables off-chain monitors and subgraphs to attribute every
-financial operation to a specific registered module without trace decoding.
+responsible module and both counterparty addresses, and enables off-chain monitors and
+subgraphs to attribute every financial operation to a specific registered module without
+trace decoding.
 
 ---
 
@@ -112,10 +108,10 @@ financial operation to a specific registered module without trace decoding.
 - **`moduleLoss` minting risk is pre-existing.** `moduleLoss` proxies `coverLoss`, which can
   mint ZCHF if the reserve is depleted. This is the same capability `moduleMint` already
   provided; no new attack surface is introduced.
-- **`moduleTransfer` is limited to the registry's own balance** — it cannot access any other
-  address's funds. The registry's ZCHF balance consists only of transiently escrowed proposal
-  fees (which are always cleared by `accept`/`revoke`). No stranded-balance risk in normal
-  operation.
-- **Gas:** `moduleProfit` (~39k gas) is cheaper than `moduleMint` (~59k) since `collectProfits`
-  performs a single internal transfer rather than minting. `moduleLoss` (~61k) is comparable
-  to `moduleMint` since it may need to mint into the reserve first.
+- **`moduleTransfer` redesign** — the original implementation used `zchf.transfer(target, amount)`,
+  limiting it to the registry's own balance. It was updated to `zchf.transferFrom(source, target, amount)`,
+  granting it the same arbitrary-source power as `moduleProfit` and `moduleBurn`. This change is
+  intentional and expands the proxy's utility for modules that need to move ZCHF between positions.
+- **Gas:** `moduleProfit` (~39k) and `moduleTransfer` (~41k) are cheaper than `moduleMint` (~59k)
+  since they perform a single internal transfer. `moduleLoss` (~61k) is comparable to `moduleMint`
+  since it may mint into the reserve first.

--- a/test/ModuleRegistryTests.ts
+++ b/test/ModuleRegistryTests.ts
@@ -1,0 +1,414 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { Equity, Frankencoin, ModuleRegistry } from "../typechain";
+import { evm_increaseTime } from "./helper";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+// ── Mainnet addresses ────────────────────────────────────────────────────────
+
+const ZCHF_ADDR  = "0xB58E61C3098d85632Df34EecfB899A1Ed80921cB";
+const ZCHF_WHALE = "0x9642b23Ed1E01Df1092B92641051881a322F5D4E";
+const FORK_BLOCK = 24977371;
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const DAY          = 86400n;
+const THIRTY_DAYS  = 30n * DAY;
+const PROPOSAL_FEE = ethers.parseEther("1000");
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function parseEvent(
+  registry: ModuleRegistry,
+  tx: Awaited<ReturnType<typeof registry.propose>>,
+  name: string
+) {
+  const receipt = await tx.wait();
+  return receipt!.logs
+    .map((log) => { try { return registry.interface.parseLog(log); } catch { return null; } })
+    .find((e) => e?.name === name);
+}
+
+// ── Suite ────────────────────────────────────────────────────────────────────
+
+describe("ModuleRegistry", function () {
+  let owner:     HardhatEthersSigner;
+  let alice:     HardhatEthersSigner; // proposer — funded with ZCHF from whale
+  let bob:       HardhatEthersSigner; // permissionless accept caller; zero FPS
+  let whale:     HardhatEthersSigner; // impersonated ZCHF whale; also invests FPS
+
+  let zchf:     Frankencoin;
+  let equity:   Equity;
+  let registry: ModuleRegistry;
+
+  // ── Global fork setup ──────────────────────────────────────────────────────
+
+  before(async function () {
+    [owner, alice, bob] = await ethers.getSigners();
+
+    const alchemyKey = process.env.ALCHEMY_RPC_KEY;
+    await ethers.provider.send("hardhat_reset", [
+      {
+        forking: {
+          jsonRpcUrl: `https://eth-mainnet.g.alchemy.com/v2/${alchemyKey}`,
+          blockNumber: FORK_BLOCK,
+        },
+      },
+    ]);
+
+    // Fund local signers with ETH so they can send transactions
+    for (const s of [owner, alice, bob]) {
+      await ethers.provider.send("hardhat_setBalance", [
+        s.address,
+        `0x${ethers.parseEther("10").toString(16)}`,
+      ]);
+    }
+
+    // Fund and impersonate ZCHF whale
+    await owner.sendTransaction({ to: ZCHF_WHALE, value: ethers.parseEther("1") });
+    await ethers.provider.send("hardhat_impersonateAccount", [ZCHF_WHALE]);
+    whale = await ethers.getSigner(ZCHF_WHALE);
+
+    // Attach to existing mainnet contracts
+    zchf   = await ethers.getContractAt("Frankencoin", ZCHF_ADDR);
+    equity = await ethers.getContractAt("Equity", await zchf.reserve());
+
+    // Fund alice with ZCHF for proposal fees (multiple proposals across the suite)
+    await zchf.connect(whale).transfer(alice.address, ethers.parseEther("10000"));
+
+    // Whale invests ALL remaining ZCHF into FPS to maximise their voting stake.
+    // Equity gets infinite ZCHF allowance from Frankencoin (_allowance returns
+    // type(uint256).max when spender == address(reserve)), so no explicit approve needed.
+    const investAmount = await zchf.balanceOf(ZCHF_WHALE);
+    await equity.connect(whale).invest(investAmount, 0n);
+
+    // Advance 730 days so the freshly-minted FPS votes accumulate to a meaningful
+    // share before any test runs. Existing FPS holders' votes also grow, but the
+    // whale's large stake makes them proportionally competitive at the 2% quorum.
+    await evm_increaseTime(730n * DAY);
+
+    // Deploy and register registry as a ZCHF minter
+    registry = await ethers.deployContract("ModuleRegistry", [ZCHF_ADDR]);
+
+    const minFee    = await zchf.MIN_FEE();
+    const minPeriod = await zchf.MIN_APPLICATION_PERIOD();
+    // Alice pays the suggestMinter fee — whale has no ZCHF left after full FPS investment
+    await zchf.connect(alice).suggestMinter(
+      await registry.getAddress(), minPeriod, minFee, "ModuleRegistry"
+    );
+    await evm_increaseTime(minPeriod + 1n);
+
+    console.log("\n=== ModuleRegistry fork setup ===");
+    console.log("Block    :", FORK_BLOCK);
+    console.log("Registry :", await registry.getAddress());
+    console.log("ZCHF     :", ZCHF_ADDR);
+    console.log("Equity   :", await equity.getAddress());
+    console.log("Whale FPS:", ethers.formatEther(await equity.balanceOf(ZCHF_WHALE)));
+  });
+
+  after(async function () {
+    await ethers.provider.send("hardhat_reset", []);
+  });
+
+  // ── Constructor ───────────────────────────────────────────────────────────
+
+  describe("constructor", function () {
+    it("zchf reference is correct", async function () {
+      expect(await registry.zchf()).to.equal(ZCHF_ADDR);
+    });
+
+    it("VETO_PERIOD is 30 days", async function () {
+      expect(await registry.VETO_PERIOD()).to.equal(THIRTY_DAYS);
+    });
+
+    it("MIN_PROPOSAL_FEE is 1000 ZCHF", async function () {
+      expect(await registry.MIN_PROPOSAL_FEE()).to.equal(PROPOSAL_FEE);
+    });
+
+    it("registry is a registered ZCHF minter", async function () {
+      expect(await zchf.isMinter(await registry.getAddress())).to.be.true;
+    });
+
+    it("no address is active on deployment", async function () {
+      expect(await registry.isActive(alice.address)).to.be.false;
+      expect(await registry.isActive(bob.address)).to.be.false;
+    });
+  });
+
+  // ── propose() guards ──────────────────────────────────────────────────────
+
+  describe("propose() guards", function () {
+    it("reverts FeeTooLow when fee is below the minimum", async function () {
+      const block = await ethers.provider.getBlock("latest");
+      const exp = BigInt(block!.timestamp) + THIRTY_DAYS + 365n * DAY;
+      await zchf.connect(alice).approve(await registry.getAddress(), PROPOSAL_FEE - 1n);
+      await expect(
+        registry.connect(alice).propose(bob.address, PROPOSAL_FEE - 1n, exp, "")
+      ).to.be.revertedWithCustomError(registry, "FeeTooLow");
+    });
+
+    it("reverts InvalidExpiration when expiration is not strictly past the veto window", async function () {
+      const block = await ethers.provider.getBlock("latest");
+      const tooSoon = BigInt(block!.timestamp) + THIRTY_DAYS;
+      await zchf.connect(alice).approve(await registry.getAddress(), PROPOSAL_FEE);
+      await expect(
+        registry.connect(alice).propose(bob.address, PROPOSAL_FEE, tooSoon, "")
+      ).to.be.revertedWithCustomError(registry, "InvalidExpiration");
+    });
+  });
+
+  // ── Revoke path ───────────────────────────────────────────────────────────
+  // alice proposes bob.address → veto window open → whale (FPS holder) revokes
+
+  describe("propose() and revoke()", function () {
+    let proposalExpiration: bigint;
+    let aliceBalanceBefore: bigint;
+    let reserveBalanceBefore: bigint;
+
+    before(async function () {
+      // The 730-day warp in setup gives the whale sufficient accumulated FPS
+      // votes relative to existing mainnet holders. No additional warp needed.
+    });
+
+    it("emits ModuleProposed with category New", async function () {
+      const block = await ethers.provider.getBlock("latest");
+      proposalExpiration = BigInt(block!.timestamp) + THIRTY_DAYS + 365n * DAY;
+
+      await zchf.connect(alice).approve(await registry.getAddress(), PROPOSAL_FEE);
+      aliceBalanceBefore    = await zchf.balanceOf(alice.address);
+      reserveBalanceBefore  = await zchf.balanceOf(await equity.getAddress());
+
+      const tx    = await registry.connect(alice).propose(bob.address, PROPOSAL_FEE, proposalExpiration, "first proposal");
+      const event = await parseEvent(registry, tx, "ModuleProposed");
+
+      expect(event).to.not.be.undefined;
+      expect(event!.args.module).to.equal(bob.address);
+      expect(event!.args.proposer).to.equal(alice.address);
+      expect(event!.args.category).to.equal(0n); // ProposalCategory.New
+      expect(event!.args.expiration).to.equal(proposalExpiration);
+      expect(event!.args.message).to.equal("first proposal");
+    });
+
+    it("fee is deducted from the proposer", async function () {
+      expect(await zchf.balanceOf(alice.address)).to.equal(aliceBalanceBefore - PROPOSAL_FEE);
+    });
+
+    it("proposal struct is stored correctly", async function () {
+      const p = await registry.proposals(bob.address);
+      expect(p.proposer).to.equal(alice.address);
+      expect(p.fee).to.equal(PROPOSAL_FEE);
+      expect(p.expiration).to.equal(proposalExpiration);
+      expect(p.activateAt).to.be.gt(0n);
+    });
+
+    it("reverts AlreadyProposed on duplicate proposal", async function () {
+      const block = await ethers.provider.getBlock("latest");
+      const exp = BigInt(block!.timestamp) + THIRTY_DAYS + 365n * DAY;
+      await zchf.connect(alice).approve(await registry.getAddress(), PROPOSAL_FEE);
+      await expect(
+        registry.connect(alice).propose(bob.address, PROPOSAL_FEE, exp, "")
+      ).to.be.revertedWithCustomError(registry, "AlreadyProposed");
+    });
+
+    it("reverts NoProposal when revoking an address with no pending proposal", async function () {
+      await expect(
+        registry.connect(whale).revoke(alice.address, [], "no proposal")
+      ).to.be.revertedWithCustomError(registry, "NoProposal");
+    });
+
+    it("reverts NotQualified when the caller holds no FPS votes", async function () {
+      await expect(
+        registry.connect(bob).revoke(bob.address, [], "not qualified")
+      ).to.be.revertedWithCustomError(equity, "NotQualified");
+    });
+
+    it("emits ModuleRevoked when a qualified FPS holder revokes within the veto window", async function () {
+      await expect(registry.connect(whale).revoke(bob.address, [], "rejected"))
+        .to.emit(registry, "ModuleRevoked")
+        .withArgs(bob.address, ZCHF_WHALE, "rejected");
+    });
+
+    it("deposit is forwarded to the reserve as profit", async function () {
+      expect(await zchf.balanceOf(await equity.getAddress())).to.be.gte(
+        reserveBalanceBefore + PROPOSAL_FEE
+      );
+    });
+
+    it("proposal struct is deleted after revoke", async function () {
+      const p = await registry.proposals(bob.address);
+      expect(p.activateAt).to.equal(0n);
+    });
+
+    it("revoked module is not active", async function () {
+      expect(await registry.isActive(bob.address)).to.be.false;
+    });
+  });
+
+  // ── Accept path ───────────────────────────────────────────────────────────
+  // alice proposes alice.address → veto window passes → anyone calls accept()
+
+  describe("accept()", function () {
+    let proposalExpiration: bigint;
+    let aliceBalanceBefore: bigint;
+
+    it("emits ModuleProposed on a fresh proposal", async function () {
+      const block = await ethers.provider.getBlock("latest");
+      proposalExpiration = BigInt(block!.timestamp) + THIRTY_DAYS + 365n * DAY;
+
+      await zchf.connect(alice).approve(await registry.getAddress(), PROPOSAL_FEE);
+      aliceBalanceBefore = await zchf.balanceOf(alice.address);
+
+      await expect(
+        registry.connect(alice).propose(alice.address, PROPOSAL_FEE, proposalExpiration, "accept test")
+      ).to.emit(registry, "ModuleProposed");
+    });
+
+    it("reverts VetoPeriodActive when accept is called before the window closes", async function () {
+      await expect(registry.connect(bob).accept(alice.address))
+        .to.be.revertedWithCustomError(registry, "VetoPeriodActive");
+    });
+
+    it("reverts VetoPeriodOver when revoke is called after the window closes", async function () {
+      await evm_increaseTime(THIRTY_DAYS + 1n);
+      await expect(registry.connect(whale).revoke(alice.address, [], "too late"))
+        .to.be.revertedWithCustomError(registry, "VetoPeriodOver");
+    });
+
+    it("reverts NoProposal when accept is called for an address without a pending proposal", async function () {
+      await expect(registry.connect(bob).accept(bob.address))
+        .to.be.revertedWithCustomError(registry, "NoProposal");
+    });
+
+    it("emits ModuleAccepted with sender and expiration", async function () {
+      await expect(registry.connect(bob).accept(alice.address))
+        .to.emit(registry, "ModuleAccepted")
+        .withArgs(alice.address, bob.address, proposalExpiration);
+    });
+
+    it("moduleExpiry is set to the proposed expiration", async function () {
+      expect(await registry.moduleExpiry(alice.address)).to.equal(proposalExpiration);
+    });
+
+    it("deposit is refunded to the proposer", async function () {
+      expect(await zchf.balanceOf(alice.address)).to.equal(aliceBalanceBefore);
+    });
+
+    it("proposal struct is cleared after accept", async function () {
+      const p = await registry.proposals(alice.address);
+      expect(p.activateAt).to.equal(0n);
+      expect(p.fee).to.equal(0n);
+    });
+
+    it("module is active after accept", async function () {
+      expect(await registry.isActive(alice.address)).to.be.true;
+    });
+  });
+
+  // ── Minting proxy ─────────────────────────────────────────────────────────
+  // alice.address is the active module; alice (signer) calls moduleMint/moduleBurn
+
+  describe("moduleMint() and moduleBurn()", function () {
+    const AMOUNT = ethers.parseEther("500");
+
+    it("reverts NotActive for a caller that is not a registered module", async function () {
+      await expect(registry.connect(bob).moduleMint(owner.address, AMOUNT))
+        .to.be.revertedWithCustomError(registry, "NotActive");
+      await expect(registry.connect(bob).moduleBurn(owner.address, AMOUNT))
+        .to.be.revertedWithCustomError(registry, "NotActive");
+    });
+
+    it("active module can moduleMint ZCHF to any target", async function () {
+      const balBefore = await zchf.balanceOf(owner.address);
+      await registry.connect(alice).moduleMint(owner.address, AMOUNT);
+      expect(await zchf.balanceOf(owner.address)).to.equal(balBefore + AMOUNT);
+    });
+
+    it("active module can moduleBurn ZCHF from any address (minterOnly bypasses allowance)", async function () {
+      const balBefore = await zchf.balanceOf(owner.address);
+      await registry.connect(alice).moduleBurn(owner.address, AMOUNT);
+      expect(await zchf.balanceOf(owner.address)).to.equal(balBefore - AMOUNT);
+    });
+  });
+
+  // ── Extension ─────────────────────────────────────────────────────────────
+
+  describe("propose() — extension", function () {
+    let extendedExpiration: bigint;
+
+    it("emits ModuleProposed with category Extension", async function () {
+      const currentExpiry  = await registry.moduleExpiry(alice.address);
+      extendedExpiration   = currentExpiry + 180n * DAY;
+
+      await zchf.connect(alice).approve(await registry.getAddress(), PROPOSAL_FEE);
+      const tx    = await registry.connect(alice).propose(alice.address, PROPOSAL_FEE, extendedExpiration, "extend TTL");
+      const event = await parseEvent(registry, tx, "ModuleProposed");
+
+      expect(event).to.not.be.undefined;
+      expect(event!.args.category).to.equal(1n); // ProposalCategory.Extension
+      expect(event!.args.expiration).to.equal(extendedExpiration);
+    });
+
+    it("moduleExpiry is updated to the extended value after accept", async function () {
+      await evm_increaseTime(THIRTY_DAYS + 1n);
+      await registry.connect(bob).accept(alice.address);
+      expect(await registry.moduleExpiry(alice.address)).to.equal(extendedExpiration);
+    });
+  });
+
+  // ── Retirement ────────────────────────────────────────────────────────────
+
+  describe("propose() — retirement", function () {
+    let shortLivedModule: string;
+    let retireAt: bigint;
+
+    before(async function () {
+      // Set up a module with a TTL of VETO_PERIOD + 30s so that any retirement
+      // attempt will push expiration past currentExpiry → InvalidExpiration.
+      const block  = await ethers.provider.getBlock("latest");
+      const shortTTL = BigInt(block!.timestamp) + THIRTY_DAYS + 30n;
+      shortLivedModule = ethers.Wallet.createRandom().address;
+
+      await zchf.connect(alice).approve(await registry.getAddress(), PROPOSAL_FEE);
+      await registry.connect(alice).propose(shortLivedModule, PROPOSAL_FEE, shortTTL, "short lived");
+      await evm_increaseTime(THIRTY_DAYS + 1n);
+      await registry.connect(bob).accept(shortLivedModule);
+      // shortLivedModule now has ~29 seconds of TTL left
+    });
+
+    it("reverts InvalidExpiration when remaining TTL is shorter than the veto window", async function () {
+      await zchf.connect(alice).approve(await registry.getAddress(), PROPOSAL_FEE);
+      await expect(
+        registry.connect(alice).propose(shortLivedModule, PROPOSAL_FEE, 0n, "retire short-lived")
+      ).to.be.revertedWithCustomError(registry, "InvalidExpiration");
+    });
+
+    it("emits ModuleProposed with category Retirement and overrides the expiration to activateAt", async function () {
+      await zchf.connect(alice).approve(await registry.getAddress(), PROPOSAL_FEE);
+      const tx    = await registry.connect(alice).propose(alice.address, PROPOSAL_FEE, 1n, "retire early");
+      const event = await parseEvent(registry, tx, "ModuleProposed");
+
+      expect(event).to.not.be.undefined;
+      expect(event!.args.category).to.equal(2n); // ProposalCategory.Retirement
+      retireAt = event!.args.expiration;
+
+      const p = await registry.proposals(alice.address);
+      expect(p.expiration).to.equal(retireAt);
+      expect(p.activateAt).to.equal(retireAt); // expiration is overridden to activateAt
+    });
+
+    it("moduleExpiry is set to the retirement timestamp after accept", async function () {
+      await evm_increaseTime(THIRTY_DAYS + 1n);
+      await registry.connect(bob).accept(alice.address);
+      expect(await registry.moduleExpiry(alice.address)).to.equal(retireAt);
+    });
+
+    it("module is inactive after the retirement timestamp passes", async function () {
+      expect(await registry.isActive(alice.address)).to.be.false;
+    });
+
+    it("retired module cannot moduleMint", async function () {
+      await expect(registry.connect(alice).moduleMint(owner.address, ethers.parseEther("1")))
+        .to.be.revertedWithCustomError(registry, "NotActive");
+    });
+  });
+});

--- a/test/ModuleRegistryTests.ts
+++ b/test/ModuleRegistryTests.ts
@@ -367,21 +367,22 @@ describe("ModuleRegistry", function () {
     });
 
     it("reverts NotActive for moduleTransfer when caller is not a registered module", async function () {
-      await expect(registry.connect(bob).moduleTransfer(owner.address, AMOUNT))
+      await expect(registry.connect(bob).moduleTransfer(owner.address, bob.address, AMOUNT))
         .to.be.revertedWithCustomError(registry, "NotActive");
     });
 
-    it("active module can moduleTransfer — moves ZCHF held by the registry to target", async function () {
-      // Fund the registry with ZCHF via moduleMint so it has a balance to transfer
-      await registry.connect(alice).moduleMint(await registry.getAddress(), AMOUNT);
+    it("active module can moduleTransfer — moves ZCHF from source to target without approval (minter infinite allowance)", async function () {
+      // Mint ZCHF to owner so it has a balance to be transferred from
+      await registry.connect(alice).moduleMint(owner.address, AMOUNT);
 
-      const registryBalBefore = await zchf.balanceOf(await registry.getAddress());
-      const ownerBalBefore    = await zchf.balanceOf(owner.address);
+      const ownerBalBefore = await zchf.balanceOf(owner.address);
+      const bobBalBefore   = await zchf.balanceOf(bob.address);
 
-      await registry.connect(alice).moduleTransfer(owner.address, AMOUNT);
+      // Module transfers from owner → bob without owner approving the registry
+      await registry.connect(alice).moduleTransfer(owner.address, bob.address, AMOUNT);
 
-      expect(await zchf.balanceOf(await registry.getAddress())).to.equal(registryBalBefore - AMOUNT);
-      expect(await zchf.balanceOf(owner.address)).to.equal(ownerBalBefore + AMOUNT);
+      expect(await zchf.balanceOf(owner.address)).to.equal(ownerBalBefore - AMOUNT);
+      expect(await zchf.balanceOf(bob.address)).to.equal(bobBalBefore + AMOUNT);
     });
   });
 

--- a/test/ModuleRegistryTests.ts
+++ b/test/ModuleRegistryTests.ts
@@ -330,6 +330,61 @@ describe("ModuleRegistry", function () {
     });
   });
 
+  // ── Reserve proxy ─────────────────────────────────────────────────────────
+  // alice.address is the active module; alice (signer) calls moduleProfit/moduleLoss
+
+  describe("moduleProfit() and moduleLoss()", function () {
+    const AMOUNT = ethers.parseEther("100");
+
+    it("reverts NotActive for a caller that is not a registered module", async function () {
+      await expect(registry.connect(bob).moduleProfit(owner.address, AMOUNT))
+        .to.be.revertedWithCustomError(registry, "NotActive");
+      await expect(registry.connect(bob).moduleLoss(owner.address, AMOUNT))
+        .to.be.revertedWithCustomError(registry, "NotActive");
+    });
+
+    it("active module can moduleProfit — moves ZCHF from source to reserve", async function () {
+      // Give owner some ZCHF to forward as profit
+      await registry.connect(alice).moduleMint(owner.address, AMOUNT);
+
+      const ownerBalBefore   = await zchf.balanceOf(owner.address);
+      const reserveBalBefore = await zchf.balanceOf(await equity.getAddress());
+
+      await registry.connect(alice).moduleProfit(owner.address, AMOUNT);
+
+      expect(await zchf.balanceOf(owner.address)).to.equal(ownerBalBefore - AMOUNT);
+      expect(await zchf.balanceOf(await equity.getAddress())).to.be.gte(reserveBalBefore + AMOUNT);
+    });
+
+    it("active module can moduleLoss — moves ZCHF from reserve to source", async function () {
+      const bobBalBefore = await zchf.balanceOf(bob.address);
+
+      await registry.connect(alice).moduleLoss(bob.address, AMOUNT);
+
+      expect(await zchf.balanceOf(bob.address)).to.equal(bobBalBefore + AMOUNT);
+      // Reserve may be topped up by minting if equity was insufficient;
+      // just verify the recipient received the full amount.
+    });
+
+    it("reverts NotActive for moduleTransfer when caller is not a registered module", async function () {
+      await expect(registry.connect(bob).moduleTransfer(owner.address, AMOUNT))
+        .to.be.revertedWithCustomError(registry, "NotActive");
+    });
+
+    it("active module can moduleTransfer — moves ZCHF held by the registry to target", async function () {
+      // Fund the registry with ZCHF via moduleMint so it has a balance to transfer
+      await registry.connect(alice).moduleMint(await registry.getAddress(), AMOUNT);
+
+      const registryBalBefore = await zchf.balanceOf(await registry.getAddress());
+      const ownerBalBefore    = await zchf.balanceOf(owner.address);
+
+      await registry.connect(alice).moduleTransfer(owner.address, AMOUNT);
+
+      expect(await zchf.balanceOf(await registry.getAddress())).to.equal(registryBalBefore - AMOUNT);
+      expect(await zchf.balanceOf(owner.address)).to.equal(ownerBalBefore + AMOUNT);
+    });
+  });
+
   // ── Extension ─────────────────────────────────────────────────────────────
 
   describe("propose() — extension", function () {


### PR DESCRIPTION
## Summary

- Add `ModuleRegistry` contract: a governance-gated proxy that controls which contracts may mint and burn ZCHF
- Modules go through a 30-day veto window (`propose` → `accept` / `revoke`) before gaining minting access
- Three proposal categories auto-inferred from expiration: **New**, **Extension**, **Retirement**
- `moduleMint` / `moduleBurn` proxy to ZCHF; only active (non-expired) modules may call them
- Add `moduleProfit` / `moduleLoss` / `moduleTransfer` proxy functions for full reserve interaction surface
  - `moduleProfit(source, amount)` → `zchf.collectProfits` (source → reserve)
  - `moduleLoss(source, amount)` → `zchf.coverLoss` (reserve → source)
  - `moduleTransfer(source, target, amount)` → `zchf.transferFrom` (minter infinite-allowance, no approval needed)
- Expose `zchf()` view on `IModuleRegistry` so downstream modules can derive the ZCHF address from the registry
- `MAX_MODULE_LIFETIME = 100 * 365 days` cap on New and Extension proposals
- `moduleExpiry` typed as `mapping(address => uint64)` (was `uint256`), removing silent narrowing cast
- Explicit named imports throughout (`import {X} from "..."`)
- NatSpec on all interfaces, events, errors, and functions; `sender` field added to `ModuleRevoked` / `ModuleAccepted` events
- Hardhat fork test suite against mainnet (block 24977371) covering full lifecycle + all proxy functions
- Security audit reports: `report/2026-04-28-01-module-registry.md`, `report/2026-04-28-02-module-registry-proxy-functions.md`

## Test plan

- [x] `yarn test test/ModuleRegistryTests.ts` passes against mainnet fork (41 tests)
- [x] `propose()` reverts `InvalidExpiration` for expiry beyond `MAX_MODULE_LIFETIME`
- [x] `revoke()` sends fee to reserve; `accept()` refunds fee to proposer
- [x] `moduleMint` / `moduleBurn` revert `NotActive` for expired or unregistered modules
- [x] `moduleProfit` moves ZCHF from source to reserve without allowance
- [x] `moduleLoss` moves ZCHF from reserve to source (mints if reserve insufficient)
- [x] `moduleTransfer` moves ZCHF between arbitrary addresses via minter infinite-allowance

🤖 Generated with [Claude Code](https://claude.com/claude-code)