### PR TITLE
feat: add StablecoinBridge for CHFAU

### DIFF
--- a/exports/abis/swap/StablecoinBridgeV1.ts
+++ b/exports/abis/swap/StablecoinBridgeV1.ts
@@ -1,0 +1,193 @@
+export const StablecoinBridgeV1ABI = [
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "other",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "zchfAddress",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "limit_",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "time",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "expiration",
+        type: "uint256",
+      },
+    ],
+    name: "Expired",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "limit",
+        type: "uint256",
+      },
+    ],
+    name: "Limit",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "token",
+        type: "address",
+      },
+    ],
+    name: "UnsupportedToken",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "burn",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "burnAndSend",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "chf",
+    outputs: [
+      {
+        internalType: "contract IERC20",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "horizon",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "limit",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "mint",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "mintTo",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "minted",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "zchf",
+    outputs: [
+      {
+        internalType: "contract IFrankencoin",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;

--- a/exports/abis/swap/StablecoinBridgeV2.ts
+++ b/exports/abis/swap/StablecoinBridgeV2.ts
@@ -1,4 +1,4 @@
-export const StablecoinBridgeABI = [
+export const StablecoinBridgeV2ABI = [
   {
     inputs: [
       {
@@ -64,10 +64,105 @@ export const StablecoinBridgeABI = [
     type: "error",
   },
   {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "zchfHolder",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "Burn",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "Credit",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "Mint",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "Payout",
+    type: "event",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "balanceOf",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [
       {
         internalType: "uint256",
-        name: "amount",
+        name: "zchfAmount",
         type: "uint256",
       },
     ],
@@ -85,7 +180,25 @@ export const StablecoinBridgeABI = [
       },
       {
         internalType: "uint256",
-        name: "amount",
+        name: "zchfAmount",
+        type: "uint256",
+      },
+    ],
+    name: "burnAndCredit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "zchfAmount",
         type: "uint256",
       },
     ],
@@ -102,6 +215,38 @@ export const StablecoinBridgeABI = [
         internalType: "contract IERC20",
         name: "",
         type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    name: "credits",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "decimalMultiplier",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
       },
     ],
     stateMutability: "view",
@@ -175,6 +320,19 @@ export const StablecoinBridgeABI = [
       },
     ],
     stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+    ],
+    name: "payoutCredit",
+    outputs: [],
+    stateMutability: "nonpayable",
     type: "function",
   },
   {

--- a/exports/address.config.ts
+++ b/exports/address.config.ts
@@ -41,6 +41,8 @@ export const ADDRESS: ChainAddressMap = {
     xchfToken: "0xb4272071ecadd69d933adcd19ca99fe80664fc08",
     stablecoinBridgeVCHF: "0x3b71ba73299f925a837836160c3e1fec74340403",
     vchfToken: "0x79d4f0232A66c4c91b89c76362016A1707CFBF4f",
+    stablecoinBridgeCHFAU: "0x3e445ff4ddDf0ff8aE7458c9746eD80bD664F6C1",
+    chfauToken: "0xBD4DfC058eb95b8De5ceAF39966A1a70F5556F78",
 
     // multi chain support
     transferReference: "0xf98c221661F51578f5E5236B189a493E2a8a1916",

--- a/exports/address.types.ts
+++ b/exports/address.types.ts
@@ -87,6 +87,8 @@ export type ChainAddressMainnet = {
   xchfToken: Address;
   stablecoinBridgeVCHF: Address;
   vchfToken: Address;
+  stablecoinBridgeCHFAU: Address;
+  chfauToken: Address;
 
   // multi chain support
   transferReference: Address; // separate SC for mainnet transfers

--- a/exports/index.ts
+++ b/exports/index.ts
@@ -51,7 +51,8 @@ export * from "./abis/stablecoin/Frankencoin";
 export * from "./abis/stablecoin/IBasicFrankencoin";
 export * from "./abis/stablecoin/IFrankencoin";
 
-export * from "./abis/swap/StablecoinBridge";
+export * from "./abis/swap/StablecoinBridgeV1";
+export * from "./abis/swap/StablecoinBridgeV2";
 
 export * from "./abis/transfer/ITransferReference";
 export * from "./abis/transfer/TransferReference";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frankencoin/zchf",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "It shall support a wide range of collateralized minting methods that are governed by a democratic process.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frankencoin/zchf",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "It shall support a wide range of collateralized minting methods that are governed by a democratic process.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Add \`stablecoinBridgeCHFAU\` and \`chfauToken\` contract addresses to the mainnet address config
- Add corresponding \`stablecoinBridgeCHFAU\` and \`chfauToken\` fields to \`ChainAddressMainnet\` type
- Split \`StablecoinBridgeABI\` into \`StablecoinBridgeV1ABI\` and \`StablecoinBridgeV2ABI\` (old \`StablecoinBridge.ts\` renamed to V1, new V2 added)
- Update \`exports/index.ts\` to export both V1 and V2 ABIs
- Bump package version to \`0.3.23\`

## Test plan
- [ ] Verify CHFAU bridge address (\`0x3e445ff4ddDf0ff8aE7458c9746eD80bD664F6C1\`) is correct on mainnet
- [ ] Verify CHFAU token address (\`0xBD4DfC058eb95b8De5ceAF39966A1a70F5556F78\`) is correct on mainnet
- [ ] Confirm \`StablecoinBridgeV1ABI\` and \`StablecoinBridgeV2ABI\` are both exported correctly
- [ ] Check that existing consumers of \`StablecoinBridgeABI\` are updated to use V1 or V2
- [ ] Confirm TypeScript types compile without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)