### PR TITLE
Add TransferWithAuthorization V2 sidecar with ERC-1271 bytes overloads

### DIFF
--- a/contracts/test/TestContractWallet.sol
+++ b/contracts/test/TestContractWallet.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract TestContractWallet {
+    address public owner;
+    bytes4 private constant MAGICVALUE = 0x1626ba7e;
+
+    constructor(address owner_) {
+        owner = owner_;
+    }
+
+    function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4) {
+        if (signature.length != 65) return 0xffffffff;
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 32))
+            v := byte(0, calldataload(add(signature.offset, 64)))
+        }
+        if (v < 27) v += 27;
+        address recovered = ecrecover(hash, v, r, s);
+        if (recovered != address(0) && recovered == owner) return MAGICVALUE;
+        return 0xffffffff;
+    }
+}
+
+contract TestAlwaysValidWallet {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        return 0x1626ba7e;
+    }
+}
+
+contract TestRejectingWallet {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        return 0xffffffff;
+    }
+}
+
+contract TestRevertingWallet {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        revert("wallet reverted");
+    }
+}
+
+contract TestShortReturnWallet {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        assembly ("memory-safe") {
+            mstore(0, shl(224, 0x1626ba7e))
+            return(0, 4)
+        }
+    }
+}
+
+contract TestMalformedReturnWallet {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        assembly ("memory-safe") {
+            mstore(0, or(shl(224, 0x1626ba7e), 1))
+            return(0, 32)
+        }
+    }
+}
+
+contract TestOversizedReturnWallet {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        assembly ("memory-safe") {
+            mstore(0, shl(224, 0x1626ba7e))
+            return(0, 0x100000)
+        }
+    }
+}

--- a/contracts/transfer/ITransferWithAuthorizationV2.sol
+++ b/contracts/transfer/ITransferWithAuthorizationV2.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ITransferWithAuthorization} from "./ITransferWithAuthorization.sol";
+
+/**
+ * @title ITransferWithAuthorizationV2
+ * @notice EIP-3009 + ERC-7598 sidecar interface.
+ * @dev Classic inherited `(v, r, s)` functions are ECDSA-only. The `bytes` overloads use ECDSA
+ *      for codeless EOAs and ERC-1271, without ECDSA fallback, for addresses with code.
+ */
+interface ITransferWithAuthorizationV2 is ITransferWithAuthorization {
+    error CallerMustBeDeployer();
+
+    function eip712Domain() external view returns (bytes1 fields, string memory name, string memory version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] memory extensions);
+
+    function transferWithAuthorization(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, bytes calldata signature) external;
+
+    function receiveWithAuthorization(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, bytes calldata signature) external;
+
+    function cancelAuthorization(address authorizer, bytes32 nonce, bytes calldata signature) external;
+}

--- a/contracts/transfer/TransferWithAuthorizationV2.sol
+++ b/contracts/transfer/TransferWithAuthorizationV2.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ITransferWithAuthorizationV2} from "./ITransferWithAuthorizationV2.sol";
+import {IERC20} from "../erc20/IERC20.sol";
+import {ECDSA} from "../utils/ECDSA.sol";
+import {SignatureChecker} from "../utils/SignatureChecker.sol";
+
+/**
+ * @title TransferWithAuthorizationV2
+ * @notice EIP-3009 sidecar with ERC-7598/ERC-1271 smart-account support for Frankencoin (ZCHF).
+ *
+ * Approved minters on the Frankencoin contract hold an implicit infinite allowance over
+ * every ZCHF balance. This contract leverages that to execute transferFrom on behalf of
+ * any holder who signs a valid authorization — no on-chain approve() required. Signature
+ * validation is therefore the only gate on that allowance.
+ *
+ * Two signature schemes, deliberately kept separate:
+ *
+ *   - The classic EIP-3009 `(v, r, s)` entrypoints recover ECDSA only, regardless of whether
+ *     `from` has code. They preserve the signature semantics of the EIP-3009 interface, so an
+ *     integrator calling them always gets plain secp256k1 verification.
+ *   - The ERC-7598 `bytes` overloads own smart-account support and route through
+ *     SignatureChecker: EOA ECDSA when `from` has no code, ERC-1271 when it does.
+ *
+ * Other spec-compatible implementations may route both forms through one checker. V2
+ * intentionally does not: for an EIP-7702-delegated EOA the classic path continues to validate
+ * root-key ECDSA, while the bytes path follows the delegated account's ERC-1271 policy.
+ *
+ * V2 tightens ECDSA validation compared with V1's raw ecrecover: high-s signatures and
+ * noncanonical v values are rejected, and failed/zero-address recovery is always invalid.
+ *
+ * The EIP-712 domain name is the compile-time constant "Frankencoin", matching both
+ * Frankencoin.name() and BridgedFrankencoin.name(). Unlike V1 it is no longer read from the
+ * asset during initialize, which keeps the domain separator independent of initialization
+ * state — but it also means initialize() must only ever be pointed at a ZCHF-named asset.
+ *
+ * Deployment and initialization:
+ *   1. Deploy this contract via the Arachnid CREATE2 factory (no constructor args — identical bytecode = identical address on every chain).
+ *   2. Call initialize(asset) with the chain-specific ZCHF/bridged-token address. Only the hardcoded deployer may do this.
+ *
+ * Governance activation after deployment:
+ *   1. Ensure the account calling suggestMinter holds at least ZCHF.MIN_FEE() in ZCHF; suggestMinter debits it from msg.sender.
+ *   2. Call ZCHF.suggestMinter(address(this), ZCHF.MIN_APPLICATION_PERIOD(), ZCHF.MIN_FEE(), "EIP-3009 sidecar V2").
+ *   3. Wait out the application period with no qualified veto from FPS holders.
+ *   4. Once ZCHF.isMinter(address(this)) == true, the contract is live. Until then every
+ *      authorization reverts for lack of allowance — deploying alone activates nothing.
+ */
+contract TransferWithAuthorizationV2 is ITransferWithAuthorizationV2 {
+    address private constant _deployer = 0x045a8395FE21CE34f0eC34d242c342ade4Ded5be;
+
+    bytes32 private constant _HASHED_NAME = keccak256(bytes("Frankencoin"));
+    bytes32 private constant _HASHED_VERSION = keccak256(bytes("1"));
+
+    IERC20 public asset;
+
+    // keccak256("TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)")
+    bytes32 public constant TRANSFER_WITH_AUTHORIZATION_TYPEHASH = 0x7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267;
+
+    // keccak256("ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)")
+    bytes32 public constant RECEIVE_WITH_AUTHORIZATION_TYPEHASH = 0xd099cc98ef71107a616c4f0f941f04c322d8e254fe26b3c6668db87aae413de8;
+
+    // keccak256("CancelAuthorization(address authorizer,bytes32 nonce)")
+    bytes32 public constant CANCEL_AUTHORIZATION_TYPEHASH = 0x158b0a9edf7a828aad02f63cd515c68ef2f50ba807396f6d12842833a1597429;
+
+    mapping(address => mapping(bytes32 => bool)) public authorizationState;
+
+    function initialize(IERC20 _asset) external {
+        if (_deployer != msg.sender) revert CallerMustBeDeployer();
+        if (address(asset) != address(0)) revert AlreadyInitialized();
+        asset = _asset;
+    }
+
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    // keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+                    bytes32(0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f),
+                    _HASHED_NAME,
+                    _HASHED_VERSION,
+                    block.chainid,
+                    address(this)
+                )
+            );
+    }
+
+    function eip712Domain() external view returns (bytes1 fields, string memory name, string memory version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] memory extensions) {
+        return (hex"0f", "Frankencoin", "1", block.chainid, address(this), bytes32(0), new uint256[](0));
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return asset.balanceOf(account);
+    }
+
+    /// @notice EIP-3009: execute a transfer with an EOA ECDSA authorization.
+    /// @dev Classic path: ECDSA recovery only, independent of whether `from` has code (xGAS / not FiatToken packing).
+    function transferWithAuthorization(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s) external {
+        _requireValidAuthorization(from, nonce, validAfter, validBefore);
+        _requireValidECDSASignature(from, keccak256(abi.encode(TRANSFER_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce)), v, r, s);
+        _markUsed(from, nonce);
+        asset.transferFrom(from, to, value);
+    }
+
+    /// @notice Encoded-signature transfer (FiatTokenV2_2 / xGAS TransferAuth).
+    /// @dev Packed `r,s,v` for EOAs; ERC-1271 when `from` has code. Does not alter the classic `(v, r, s)` path.
+    function transferWithAuthorization(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, bytes calldata signature) external {
+        _requireValidAuthorization(from, nonce, validAfter, validBefore);
+        _requireValidSignature(from, keccak256(abi.encode(TRANSFER_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce)), signature);
+        _markUsed(from, nonce);
+        asset.transferFrom(from, to, value);
+    }
+
+    /// @notice EIP-3009: receive a transfer with an EOA ECDSA authorization.
+    function receiveWithAuthorization(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s) external {
+        if (msg.sender != to) revert CallerMustBePayee();
+        _requireValidAuthorization(from, nonce, validAfter, validBefore);
+        _requireValidECDSASignature(from, keccak256(abi.encode(RECEIVE_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce)), v, r, s);
+        _markUsed(from, nonce);
+        asset.transferFrom(from, to, value);
+    }
+
+    /// @notice Encoded-signature receive (FiatTokenV2_2 / xGAS TransferAuth).
+    function receiveWithAuthorization(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, bytes calldata signature) external {
+        if (msg.sender != to) revert CallerMustBePayee();
+        _requireValidAuthorization(from, nonce, validAfter, validBefore);
+        _requireValidSignature(from, keccak256(abi.encode(RECEIVE_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce)), signature);
+        _markUsed(from, nonce);
+        asset.transferFrom(from, to, value);
+    }
+
+    /// @notice EIP-3009: cancel an authorization with an EOA ECDSA signature.
+    function cancelAuthorization(address authorizer, bytes32 nonce, uint8 v, bytes32 r, bytes32 s) external {
+        if (authorizationState[authorizer][nonce]) revert AuthorizationAlreadyUsed();
+        _requireValidECDSASignature(authorizer, keccak256(abi.encode(CANCEL_AUTHORIZATION_TYPEHASH, authorizer, nonce)), v, r, s);
+        authorizationState[authorizer][nonce] = true;
+        emit AuthorizationCanceled(authorizer, nonce);
+    }
+
+    /// @notice Encoded-signature cancel (FiatTokenV2_2 / xGAS TransferAuth).
+    function cancelAuthorization(address authorizer, bytes32 nonce, bytes calldata signature) external {
+        if (authorizationState[authorizer][nonce]) revert AuthorizationAlreadyUsed();
+        _requireValidSignature(authorizer, keccak256(abi.encode(CANCEL_AUTHORIZATION_TYPEHASH, authorizer, nonce)), signature);
+        authorizationState[authorizer][nonce] = true;
+        emit AuthorizationCanceled(authorizer, nonce);
+    }
+
+    function _requireValidAuthorization(address authorizer, bytes32 nonce, uint256 validAfter, uint256 validBefore) private view {
+        if (block.timestamp <= validAfter) revert AuthorizationNotYetValid();
+        if (block.timestamp >= validBefore) revert AuthorizationExpired();
+        if (authorizationState[authorizer][nonce]) revert AuthorizationAlreadyUsed();
+    }
+
+    /// @dev Classic EIP-3009: local ECDSA validation only. No dependency on SignatureChecker/ERC-1271.
+    function _requireValidECDSASignature(address signer, bytes32 dataHash, uint8 v, bytes32 r, bytes32 s) private view {
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), dataHash));
+        if (!ECDSA.isValidSignature(signer, digest, v, r, s)) revert InvalidSignature();
+    }
+
+    /// @dev Encoded path only: EOA ECDSA or ERC-1271 depending on `signer.code.length`.
+    function _requireValidSignature(address signer, bytes32 dataHash, bytes memory signature) private view {
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), dataHash));
+        if (!SignatureChecker.isValidSignatureNow(signer, digest, signature)) revert InvalidSignature();
+    }
+
+    function _markUsed(address authorizer, bytes32 nonce) private {
+        authorizationState[authorizer][nonce] = true;
+        emit AuthorizationUsed(authorizer, nonce);
+    }
+}

--- a/contracts/utils/ECDSA.sol
+++ b/contracts/utils/ECDSA.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Local, dependency-free secp256k1 signature recovery.
+ *
+ * Only canonical signatures are accepted: `s` must be in the lower half order and
+ * `v` must be 27 or 28. A failed recovery (address(0)) is always invalid, including
+ * when the claimed signer is address(0).
+ */
+library ECDSA {
+    // secp256k1n / 2
+    uint256 private constant _HALF_ORDER = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
+
+    function isValidSignature(address signer, bytes32 hash, bytes memory signature) internal pure returns (bool) {
+        (address recovered, bool success) = tryRecover(hash, signature);
+        return success && signer != address(0) && recovered == signer;
+    }
+
+    function isValidSignature(address signer, bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (bool) {
+        (address recovered, bool success) = tryRecover(hash, v, r, s);
+        return success && signer != address(0) && recovered == signer;
+    }
+
+    function tryRecover(bytes32 hash, bytes memory signature) internal pure returns (address recovered, bool success) {
+        if (signature.length != 65) {
+            return (address(0), false);
+        }
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly ("memory-safe") {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+        return tryRecover(hash, v, r, s);
+    }
+
+    function tryRecover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address recovered, bool success) {
+        if (uint256(s) > _HALF_ORDER || (v != 27 && v != 28)) {
+            return (address(0), false);
+        }
+
+        recovered = ecrecover(hash, v, r, s);
+        success = recovered != address(0);
+    }
+}

--- a/contracts/utils/IERC1271.sol
+++ b/contracts/utils/IERC1271.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC1271 {
+    function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4 magicValue);
+}

--- a/contracts/utils/SignatureChecker.sol
+++ b/contracts/utils/SignatureChecker.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ECDSA} from "./ECDSA.sol";
+import {IERC1271} from "./IERC1271.sol";
+
+/**
+ * @dev Signature verification for the encoded-signature (bytes) path.
+ *
+ * Routing matches Circle FiatToken `SignatureChecker` and OpenZeppelin (used by xGAS):
+ *   - `signer.code.length == 0`: ECDSA recovery of a packed `r,s,v` signature.
+ *   - `signer.code.length > 0`: ERC-1271 only.
+ *
+ * There is no ECDSA-first fallback when the signer has code. After EIP-7702 delegation the
+ * bytes path follows the account's current ERC-1271 policy. Classic EIP-3009 `(v, r, s)`
+ * entrypoints do not use this library.
+ *
+ * ECDSA validation is delegated to the local ECDSA primitive, which rejects high-s,
+ * noncanonical `v`, failed recovery, and the zero signer.
+ */
+library SignatureChecker {
+    bytes4 private constant ERC1271_MAGICVALUE = IERC1271.isValidSignature.selector;
+
+    function isValidSignatureNow(address signer, bytes32 hash, bytes memory signature) internal view returns (bool) {
+        if (signer == address(0)) {
+            return false;
+        }
+        if (signer.code.length == 0) {
+            return ECDSA.isValidSignature(signer, hash, signature);
+        }
+        return isValidERC1271SignatureNow(signer, hash, signature);
+    }
+
+    function isValidERC1271SignatureNow(address signer, bytes32 hash, bytes memory signature) internal view returns (bool) {
+        bytes memory callData = abi.encodeCall(IERC1271.isValidSignature, (hash, signature));
+        bool success;
+        uint256 returnSize;
+        bytes32 result;
+
+        // Cap copied return data at one word. This accepts normal ABI responses while preventing
+        // a hostile account from forcing this checker to allocate/copy oversized return data.
+        assembly ("memory-safe") {
+            let output := mload(0x40)
+            mstore(output, 0)
+            success := staticcall(gas(), signer, add(callData, 0x20), mload(callData), output, 0x20)
+            returnSize := returndatasize()
+            result := mload(output)
+        }
+
+        return success && returnSize >= 32 && result == bytes32(ERC1271_MAGICVALUE);
+    }
+}

--- a/docs/transfer-with-authorization-v2.md
+++ b/docs/transfer-with-authorization-v2.md
@@ -1,0 +1,45 @@
+# TransferWithAuthorization V2
+
+`TransferWithAuthorizationV2` is an EIP-3009 sidecar for Frankencoin and CCIP-bridged Frankencoin. It adds ERC-7598 `bytes` signature overloads without changing the meaning of the classic EIP-3009 entrypoints.
+
+## Signature semantics
+
+- Classic EIP-3009 `(v, r, s)` overloads are ECDSA-only, even when the signer has code.
+- ERC-7598 `bytes` overloads use ECDSA for codeless EOAs and ERC-1271 for addresses with code. Coded accounts do not receive an ECDSA fallback.
+- For an EIP-7702 delegated EOA, the classic path therefore continues to check the root-key ECDSA signature, while the bytes path follows the delegated account's ERC-1271 policy.
+- V2 requires `v` to be 27 or 28 and rejects high-`s` signatures. This is intentionally stricter than V1's raw `ecrecover` behavior.
+- Failed recovery and recovery to the zero address are always invalid.
+
+These two signature paths are an intentional, spec-compatible boundary. Smart accounts should use the ERC-7598 bytes overloads.
+
+The local regression suite exercises the EIP-7702 boundary with a genuine type-4 authorization-list transaction: it delegates an EOA to a rejecting ERC-1271 implementation, confirms that the bytes overload follows that policy, and confirms that the classic overload still accepts the EOA's root-key ECDSA signature. The Solidity `paris` compilation target does not prevent the newer Hardhat network from executing this transaction type.
+
+The EIP-712 domain is `{ name: "Frankencoin", version: "1", chainId, verifyingContract }`. Unlike V1, the name is a compile-time constant and is not read from the configured asset during initialization.
+
+## Deployment and activation
+
+Run a dry run first:
+
+```shell
+PRIVATE_KEY=... npx hardhat run scripts/deployTransferWithAuthorizationV2.ts --network <network>
+```
+
+Deploy and initialize only after checking the predicted CREATE2 address and asset:
+
+```shell
+PRIVATE_KEY=... EXECUTE=true npx hardhat run scripts/deployTransferWithAuthorizationV2.ts --network <network>
+```
+
+The script rejects a `PRIVATE_KEY` that does not resolve to the deployer hardcoded in the contract. It deploys through the Arachnid CREATE2 factory and initializes the sidecar with the chain's configured Frankencoin asset.
+
+Deployment and initialization do not activate transfers. The sidecar relies on the token's implicit allowance for approved minters. Complete the governance procedure on each token/chain:
+
+1. Ensure the account submitting the application holds at least `ZCHF.MIN_FEE()`; the token debits the fee directly.
+2. Call `ZCHF.suggestMinter(v2Address, ZCHF.MIN_APPLICATION_PERIOD(), ZCHF.MIN_FEE(), "EIP-3009 sidecar V2")`.
+3. Allow the full application period to pass without a qualified governance veto.
+4. Confirm `ZCHF.isMinter(v2Address) == true`.
+5. Exercise a small authorization on that chain before announcing activation.
+
+Until step 4, authorizations cannot use the implicit allowance and will fail at the token transfer.
+
+After a deployment is confirmed, add its actual V2 address to `exports/address.config.ts` and the corresponding address type. Do not publish a predicted or placeholder V2 address as a deployed address.

--- a/exports/abis/transfer/ITransferWithAuthorizationV2.ts
+++ b/exports/abis/transfer/ITransferWithAuthorizationV2.ts
@@ -1,0 +1,487 @@
+export const ITransferWithAuthorizationV2ABI = [
+  {
+    inputs: [],
+    name: "AlreadyInitialized",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "AuthorizationAlreadyUsed",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "AuthorizationExpired",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "AuthorizationNotYetValid",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "CallerMustBeDeployer",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "CallerMustBePayee",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidSignature",
+    type: "error",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "authorizer",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      }
+    ],
+    name: "AuthorizationCanceled",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "authorizer",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      }
+    ],
+    name: "AuthorizationUsed",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "CANCEL_AUTHORIZATION_TYPEHASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "DOMAIN_SEPARATOR",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "RECEIVE_WITH_AUTHORIZATION_TYPEHASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "TRANSFER_WITH_AUTHORIZATION_TYPEHASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "asset",
+    outputs: [
+      {
+        internalType: "contract IERC20",
+        name: "",
+        type: "address",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "authorizer",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      }
+    ],
+    name: "authorizationState",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      }
+    ],
+    name: "balanceOf",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "authorizer",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint8",
+        name: "v",
+        type: "uint8",
+      },
+      {
+        internalType: "bytes32",
+        name: "r",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "s",
+        type: "bytes32",
+      }
+    ],
+    name: "cancelAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "authorizer",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "signature",
+        type: "bytes",
+      }
+    ],
+    name: "cancelAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "eip712Domain",
+    outputs: [
+      {
+        internalType: "bytes1",
+        name: "fields",
+        type: "bytes1",
+      },
+      {
+        internalType: "string",
+        name: "name",
+        type: "string",
+      },
+      {
+        internalType: "string",
+        name: "version",
+        type: "string",
+      },
+      {
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "verifyingContract",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "salt",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256[]",
+        name: "extensions",
+        type: "uint256[]",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "contract IERC20",
+        name: "_asset",
+        type: "address",
+      }
+    ],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validAfter",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validBefore",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "signature",
+        type: "bytes",
+      }
+    ],
+    name: "receiveWithAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validAfter",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validBefore",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint8",
+        name: "v",
+        type: "uint8",
+      },
+      {
+        internalType: "bytes32",
+        name: "r",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "s",
+        type: "bytes32",
+      }
+    ],
+    name: "receiveWithAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validAfter",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validBefore",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "signature",
+        type: "bytes",
+      }
+    ],
+    name: "transferWithAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validAfter",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validBefore",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint8",
+        name: "v",
+        type: "uint8",
+      },
+      {
+        internalType: "bytes32",
+        name: "r",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "s",
+        type: "bytes32",
+      }
+    ],
+    name: "transferWithAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  }
+] as const;

--- a/exports/abis/transfer/TransferWithAuthorizationV2.ts
+++ b/exports/abis/transfer/TransferWithAuthorizationV2.ts
@@ -1,0 +1,487 @@
+export const TransferWithAuthorizationV2ABI = [
+  {
+    inputs: [],
+    name: "AlreadyInitialized",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "AuthorizationAlreadyUsed",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "AuthorizationExpired",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "AuthorizationNotYetValid",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "CallerMustBeDeployer",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "CallerMustBePayee",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidSignature",
+    type: "error",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "authorizer",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      }
+    ],
+    name: "AuthorizationCanceled",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "authorizer",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      }
+    ],
+    name: "AuthorizationUsed",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "CANCEL_AUTHORIZATION_TYPEHASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "DOMAIN_SEPARATOR",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "RECEIVE_WITH_AUTHORIZATION_TYPEHASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "TRANSFER_WITH_AUTHORIZATION_TYPEHASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "asset",
+    outputs: [
+      {
+        internalType: "contract IERC20",
+        name: "",
+        type: "address",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      }
+    ],
+    name: "authorizationState",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      }
+    ],
+    name: "balanceOf",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "authorizer",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint8",
+        name: "v",
+        type: "uint8",
+      },
+      {
+        internalType: "bytes32",
+        name: "r",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "s",
+        type: "bytes32",
+      }
+    ],
+    name: "cancelAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "authorizer",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "signature",
+        type: "bytes",
+      }
+    ],
+    name: "cancelAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "eip712Domain",
+    outputs: [
+      {
+        internalType: "bytes1",
+        name: "fields",
+        type: "bytes1",
+      },
+      {
+        internalType: "string",
+        name: "name",
+        type: "string",
+      },
+      {
+        internalType: "string",
+        name: "version",
+        type: "string",
+      },
+      {
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "verifyingContract",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "salt",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256[]",
+        name: "extensions",
+        type: "uint256[]",
+      }
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "contract IERC20",
+        name: "_asset",
+        type: "address",
+      }
+    ],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validAfter",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validBefore",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "signature",
+        type: "bytes",
+      }
+    ],
+    name: "receiveWithAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validAfter",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validBefore",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint8",
+        name: "v",
+        type: "uint8",
+      },
+      {
+        internalType: "bytes32",
+        name: "r",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "s",
+        type: "bytes32",
+      }
+    ],
+    name: "receiveWithAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validAfter",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validBefore",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "signature",
+        type: "bytes",
+      }
+    ],
+    name: "transferWithAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validAfter",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "validBefore",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "nonce",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint8",
+        name: "v",
+        type: "uint8",
+      },
+      {
+        internalType: "bytes32",
+        name: "r",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "s",
+        type: "bytes32",
+      }
+    ],
+    name: "transferWithAuthorization",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  }
+] as const;

--- a/exports/index.ts
+++ b/exports/index.ts
@@ -56,6 +56,8 @@ export * from "./abis/swap/StablecoinBridgeV2";
 
 export * from "./abis/transfer/ITransferReference";
 export * from "./abis/transfer/TransferReference";
+export * from "./abis/transfer/ITransferWithAuthorizationV2";
+export * from "./abis/transfer/TransferWithAuthorizationV2";
 
 export * from "./abis/utils/OCR2Aggregator";
 export * from "./abis/utils/Ownable";

--- a/scripts/deployTransferWithAuthorizationV2.ts
+++ b/scripts/deployTransferWithAuthorizationV2.ts
@@ -1,0 +1,140 @@
+import hre, { ethers } from "hardhat";
+import { ADDRESS } from "../exports/address.config";
+import { mainnet } from "viem/chains";
+
+// Arachnid deterministic deployment proxy — same address on all EVM chains.
+// See: https://github.com/Arachnid/deterministic-deployment-proxy
+const ARACHNID_FACTORY = "0x4e59b44847b379578588920cA78FbF26c0B4956C";
+
+const SALT = ethers.id("TransferWithAuthorization-v2");
+
+// Must match `_deployer` in TransferWithAuthorizationV2 — it is the only address `initialize`
+// accepts. CREATE2 through the Arachnid factory is permissionless, so deploying with any other
+// key strands an uninitialisable contract at the deterministic address.
+const EXPECTED_DEPLOYER = "0x045a8395FE21CE34f0eC34d242c342ade4Ded5be";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main() {
+  const execute = process.env.EXECUTE === "true";
+
+  const privateKey = process.env.PRIVATE_KEY;
+  if (!privateKey) throw new Error("Missing PRIVATE_KEY in .env");
+  const deployer = new ethers.Wallet(privateKey, ethers.provider);
+  if (
+    ethers.getAddress(deployer.address) !== ethers.getAddress(EXPECTED_DEPLOYER)
+  ) {
+    throw new Error(
+      `PRIVATE_KEY resolves to ${deployer.address}, but the contract only accepts ${EXPECTED_DEPLOYER} as initializer.`
+    );
+  }
+  const { chainId } = await ethers.provider.getNetwork();
+  const chain = Number(chainId);
+  const network = hre.network.name;
+
+  console.log(
+    `\nUsage: EXECUTE=true npx hardhat run scripts/deployTransferWithAuthorizationV2.ts --network <name>`
+  );
+  console.log(
+    `\nMode:       ${execute ? "EXECUTE" : "dry run  (set EXECUTE=true to send transactions)"}`
+  );
+  console.log(`Network:    ${network} (chain ${chain})`);
+  console.log("Deployer:  ", deployer.address);
+  console.log(
+    "Balance:   ",
+    ethers.formatEther(await ethers.provider.getBalance(deployer.address)),
+    "ETH"
+  );
+
+  const chainAddresses = ADDRESS[chain as keyof typeof ADDRESS];
+  if (!chainAddresses)
+    throw new Error(`Chain ${chain} not found in address.config`);
+  const asset =
+    chain === mainnet.id
+      ? (chainAddresses as { frankencoin: string }).frankencoin
+      : (chainAddresses as { ccipBridgedFrankencoin: string })
+          .ccipBridgedFrankencoin;
+  if (!asset) throw new Error(`No asset address configured for chain ${chain}`);
+  console.log("Asset:      ", asset);
+
+  const factory = await ethers.getContractFactory(
+    "TransferWithAuthorizationV2"
+  );
+  const initCode = factory.bytecode;
+
+  const predicted = ethers.getCreate2Address(
+    ARACHNID_FACTORY,
+    SALT,
+    ethers.keccak256(initCode)
+  );
+  console.log("\nPredicted address:", predicted);
+
+  const existingCode = await ethers.provider.getCode(predicted);
+  if (existingCode !== "0x") {
+    console.log("Already deployed — skipping deploy step.");
+  } else if (!execute) {
+    console.log("[dry run] Would deploy via Arachnid factory.");
+  } else {
+    const tx = await deployer.sendTransaction({
+      to: ARACHNID_FACTORY,
+      data: ethers.concat([SALT, initCode]),
+    });
+    await tx.wait();
+    console.log("Deployed in tx:", tx.hash);
+
+    const deployedCode = await ethers.provider.getCode(predicted);
+    if (deployedCode === "0x")
+      throw new Error("Deployment failed — no code at predicted address.");
+    console.log("Deployed to:", predicted);
+
+    console.log("Waiting 30s for RPC propagation...");
+    await sleep(30_000);
+  }
+
+  const liveCode = await ethers.provider.getCode(predicted);
+  if (liveCode === "0x") {
+    console.log("[dry run] Would initialize with asset:", asset);
+  } else {
+    const contract = await ethers.getContractAt(
+      "TransferWithAuthorizationV2",
+      predicted,
+      deployer
+    );
+    const currentAsset = await contract.asset();
+
+    if (currentAsset !== ethers.ZeroAddress) {
+      console.log("Already initialized with asset:", currentAsset);
+    } else if (!execute) {
+      console.log("[dry run] Would initialize with asset:", asset);
+    } else {
+      const tx = await contract.initialize(asset);
+      await tx.wait();
+      console.log("Initialized in tx:", tx.hash);
+      console.log("Initialized with asset:", asset);
+
+      console.log("Waiting 30s for Etherscan to index the contract...");
+      await sleep(30_000);
+    }
+  }
+
+  if (!execute) {
+    console.log(
+      "\nDry run complete — no transactions sent. Set EXECUTE=true to deploy for real.\n"
+    );
+  }
+
+  // Deploying and initializing is not enough: the sidecar moves funds through the implicit
+  // infinite allowance that the token grants its minters, so every authorization reverts until
+  // governance has approved it.
+  console.log(
+    `\nNEXT STEP — the sidecar stays inert until it is an approved minter:\n` +
+      `  ZCHF.suggestMinter(${predicted}, ZCHF.MIN_APPLICATION_PERIOD(), ZCHF.MIN_FEE(), "EIP-3009 sidecar V2")\n` +
+      `  The caller must hold ZCHF.MIN_FEE(); the application period must then pass without a qualified veto.\n` +
+      `  Live once ZCHF.isMinter(${predicted}) == true.\n`
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/TransferWithAuthorizationTest.ts
+++ b/test/TransferWithAuthorizationTest.ts
@@ -1,0 +1,1236 @@
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+const INITIALIZER = "0x045a8395FE21CE34f0eC34d242c342ade4Ded5be";
+
+const transferTypes = {
+  TransferWithAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+};
+
+const receiveTypes = {
+  ReceiveWithAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+};
+
+const cancelTypes = {
+  CancelAuthorization: [
+    { name: "authorizer", type: "address" },
+    { name: "nonce", type: "bytes32" },
+  ],
+};
+
+async function domainFor(verifyingContract: string) {
+  const { chainId } = await ethers.provider.getNetwork();
+  return {
+    name: "Frankencoin",
+    version: "1",
+    chainId,
+    verifyingContract,
+  };
+}
+
+function packedSignature(sig: string) {
+  const parsed = ethers.Signature.from(sig);
+  return ethers.concat([parsed.r, parsed.s, ethers.toBeHex(parsed.v, 1)]);
+}
+
+async function impersonateInitializer() {
+  await ethers.provider.send("hardhat_impersonateAccount", [INITIALIZER]);
+  await ethers.provider.send("hardhat_setBalance", [
+    INITIALIZER,
+    "0x56BC75E2D63100000",
+  ]);
+  return ethers.getSigner(INITIALIZER);
+}
+
+describe("TransferWithAuthorizationV2", () => {
+  async function deployV2() {
+    const [owner, payer, payee, relayer] = await ethers.getSigners();
+    const frankencoin = await ethers.deployContract("Frankencoin", [0]);
+    await frankencoin.initialize(owner.address, "");
+
+    const sidecar = await ethers.deployContract("TransferWithAuthorizationV2");
+    const initializer = await impersonateInitializer();
+    await sidecar.connect(initializer).initialize(await frankencoin.getAddress());
+
+    await frankencoin.mint(owner.address, ethers.parseEther("1000"));
+    await frankencoin.mint(payer.address, ethers.parseEther("1000"));
+    await frankencoin.suggestMinter(
+      await sidecar.getAddress(),
+      await frankencoin.MIN_APPLICATION_PERIOD(),
+      await frankencoin.MIN_FEE(),
+      "EIP-3009 sidecar V2"
+    );
+
+    return { owner, payer, payee, relayer, frankencoin, sidecar };
+  }
+
+  // secp256k1 group order, used to build the malleable counterpart of a signature.
+  const SECP256K1N =
+    0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141n;
+
+  function malleate(sig: string) {
+    const parsed = ethers.Signature.from(sig);
+    return {
+      v: parsed.v === 27 ? 28 : 27,
+      r: parsed.r,
+      s: ethers.toBeHex(SECP256K1N - BigInt(parsed.s), 32),
+    };
+  }
+
+  async function signTransfer(
+    payer: SignerWithAddress,
+    sidecarAddress: string,
+    to: string,
+    value: bigint,
+    validAfter = 0n,
+    validBefore?: bigint,
+    nonce?: Uint8Array
+  ) {
+    const usedNonce = nonce ?? ethers.randomBytes(32);
+    const usedValidBefore =
+      validBefore ?? BigInt((await time.latest()) + 3600);
+    const signature = await payer.signTypedData(
+      await domainFor(sidecarAddress),
+      transferTypes,
+      {
+        from: payer.address,
+        to,
+        value,
+        validAfter,
+        validBefore: usedValidBefore,
+        nonce: usedNonce,
+      }
+    );
+    return {
+      signature,
+      packed: packedSignature(signature),
+      parsed: ethers.Signature.from(signature),
+      nonce: usedNonce,
+      validAfter,
+      validBefore: usedValidBefore,
+    };
+  }
+
+    it("exposes eip712Domain and forwards balanceOf", async () => {
+    const { sidecar, payer, frankencoin } = await loadFixture(deployV2);
+    const domain = await sidecar.eip712Domain();
+    expect(domain.fields).to.equal("0x0f");
+    expect(domain.name).to.equal("Frankencoin");
+    expect(domain.version).to.equal("1");
+    expect(domain.verifyingContract).to.equal(await sidecar.getAddress());
+    expect(await sidecar.balanceOf(payer.address)).to.equal(
+      await frankencoin.balanceOf(payer.address)
+    );
+  });
+
+  it("executes transferWithAuthorization via v,r,s and bytes overloads", async () => {
+    const { payer, payee, relayer, frankencoin, sidecar } =
+      await loadFixture(deployV2);
+    const value = ethers.parseEther("5");
+    const first = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value
+    );
+    await sidecar
+      .connect(relayer)
+      [
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        first.validAfter,
+        first.validBefore,
+        first.nonce,
+        first.parsed.v,
+        first.parsed.r,
+        first.parsed.s
+      );
+
+    const second = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value
+    );
+    await expect(
+      sidecar
+        .connect(relayer)
+        [
+          "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+        ](
+          payer.address,
+          payee.address,
+          value,
+          second.validAfter,
+          second.validBefore,
+          second.nonce,
+          second.packed
+        )
+    ).to.changeTokenBalances(frankencoin, [payer, payee], [-value, value]);
+  });
+
+  it("rejects replayed nonces", async () => {
+    const { payer, payee, sidecar } = await loadFixture(deployV2);
+    const value = ethers.parseEther("1");
+    const auth = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value
+    );
+    const args = [
+      payer.address,
+      payee.address,
+      value,
+      auth.validAfter,
+      auth.validBefore,
+      auth.nonce,
+      auth.packed,
+    ] as const;
+    await sidecar[
+      "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+    ](...args);
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](...args)
+    ).to.be.revertedWithCustomError(sidecar, "AuthorizationAlreadyUsed");
+  });
+
+  it("enforces validity window", async () => {
+    const { payer, payee, sidecar } = await loadFixture(deployV2);
+    const value = ethers.parseEther("1");
+    const future = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value,
+      BigInt((await time.latest()) + 1000)
+    );
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        future.validAfter,
+        future.validBefore,
+        future.nonce,
+        future.packed
+      )
+    ).to.be.revertedWithCustomError(sidecar, "AuthorizationNotYetValid");
+
+    const expired = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value,
+      0n,
+      BigInt((await time.latest()) - 1)
+    );
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        expired.validAfter,
+        expired.validBefore,
+        expired.nonce,
+        expired.packed
+      )
+    ).to.be.revertedWithCustomError(sidecar, "AuthorizationExpired");
+  });
+
+  it("requires msg.sender == to for receiveWithAuthorization", async () => {
+    const { payer, payee, relayer, frankencoin, sidecar } =
+      await loadFixture(deployV2);
+    const value = ethers.parseEther("3");
+    const nonce = ethers.randomBytes(32);
+    const validAfter = 0n;
+    const validBefore = BigInt((await time.latest()) + 3600);
+    const signature = await payer.signTypedData(
+      await domainFor(await sidecar.getAddress()),
+      receiveTypes,
+      {
+        from: payer.address,
+        to: payee.address,
+        value,
+        validAfter,
+        validBefore,
+        nonce,
+      }
+    );
+    const packed = packedSignature(signature);
+    await expect(
+      sidecar
+        .connect(relayer)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+        ](
+          payer.address,
+          payee.address,
+          value,
+          validAfter,
+          validBefore,
+          nonce,
+          packed
+        )
+    ).to.be.revertedWithCustomError(sidecar, "CallerMustBePayee");
+
+    await expect(
+      sidecar
+        .connect(payee)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+        ](
+          payer.address,
+          payee.address,
+          value,
+          validAfter,
+          validBefore,
+          nonce,
+          packed
+        )
+    ).to.changeTokenBalances(frankencoin, [payer, payee], [-value, value]);
+  });
+
+  it("cancels an unused nonce", async () => {
+    const { payer, payee, sidecar } = await loadFixture(deployV2);
+    const nonce = ethers.randomBytes(32);
+    const cancelSig = await payer.signTypedData(
+      await domainFor(await sidecar.getAddress()),
+      cancelTypes,
+      { authorizer: payer.address, nonce }
+    );
+    await sidecar["cancelAuthorization(address,bytes32,bytes)"](
+      payer.address,
+      nonce,
+      packedSignature(cancelSig)
+    );
+    expect(await sidecar.authorizationState(payer.address, nonce)).to.equal(
+      true
+    );
+
+    const value = ethers.parseEther("1");
+    const auth = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value,
+      0n,
+      undefined,
+      nonce
+    );
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        auth.validAfter,
+        auth.validBefore,
+        auth.nonce,
+        auth.packed
+      )
+    ).to.be.revertedWithCustomError(sidecar, "AuthorizationAlreadyUsed");
+  });
+
+  it("accepts ERC-1271 on the bytes overload and rejects it on EIP-3009 v,r,s", async () => {
+    const { owner, payee, frankencoin, sidecar } = await loadFixture(deployV2);
+    const wallet = await ethers.deployContract("TestContractWallet", [
+      owner.address,
+    ]);
+    await frankencoin.mint(await wallet.getAddress(), ethers.parseEther("50"));
+
+    const value = ethers.parseEther("8");
+    const nonce = ethers.randomBytes(32);
+    const validAfter = 0n;
+    const validBefore = BigInt((await time.latest()) + 3600);
+    const from = await wallet.getAddress();
+    const signature = await owner.signTypedData(
+      await domainFor(await sidecar.getAddress()),
+      transferTypes,
+      {
+        from,
+        to: payee.address,
+        value,
+        validAfter,
+        validBefore,
+        nonce,
+      }
+    );
+
+    const parsed = ethers.Signature.from(signature);
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+      ](
+        from,
+        payee.address,
+        value,
+        validAfter,
+        validBefore,
+        nonce,
+        parsed.v,
+        parsed.r,
+        parsed.s
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        from,
+        payee.address,
+        value,
+        validAfter,
+        validBefore,
+        nonce,
+        packedSignature(signature)
+      )
+    ).to.changeTokenBalances(
+      frankencoin,
+      [from, payee.address],
+      [-value, value]
+    );
+  });
+
+  it("turns reverting, short, and malformed ERC-1271 responses into InvalidSignature", async () => {
+    const { payee, sidecar } = await loadFixture(deployV2);
+    const validBefore = BigInt((await time.latest()) + 3600);
+
+    for (const contractName of [
+      "TestRevertingWallet",
+      "TestShortReturnWallet",
+      "TestMalformedReturnWallet",
+    ]) {
+      const wallet = await ethers.deployContract(contractName);
+      const from = await wallet.getAddress();
+      const nonce = ethers.randomBytes(32);
+
+      await expect(
+        sidecar[
+          "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+        ](
+          from,
+          payee.address,
+          0n,
+          0n,
+          validBefore,
+          nonce,
+          "0x1234"
+        )
+      ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+      expect(await sidecar.authorizationState(from, nonce)).to.equal(false);
+    }
+  });
+
+  it("accepts a valid ERC-1271 magic value without copying oversized return data", async () => {
+    const { payee, frankencoin, sidecar } = await loadFixture(deployV2);
+    const wallet = await ethers.deployContract("TestOversizedReturnWallet");
+    const from = await wallet.getAddress();
+    const value = ethers.parseEther("2");
+    const nonce = ethers.randomBytes(32);
+    const validBefore = BigInt((await time.latest()) + 3600);
+    await frankencoin.mint(from, value);
+
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        from,
+        payee.address,
+        value,
+        0n,
+        validBefore,
+        nonce,
+        "0x1234",
+        { gasLimit: 3_500_000 }
+      )
+    ).to.changeTokenBalances(frankencoin, [from, payee.address], [-value, value]);
+  });
+
+  it("routes a delegated EOA through ERC-1271 while keeping classic v,r,s on ECDSA", async () => {
+    const { payer, payee, relayer, sidecar } = await loadFixture(deployV2);
+    const value = ethers.parseEther("4");
+    const auth = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value
+    );
+
+    const rejecting = await ethers.deployContract("TestRejectingWallet");
+    const authorization = await payer.authorize({
+      address: await rejecting.getAddress(),
+    });
+    await (
+      await relayer.sendTransaction({
+        to: relayer.address,
+        authorizationList: [authorization],
+      })
+    ).wait();
+
+    expect(await ethers.provider.getCode(payer.address)).to.equal(
+      ethers.concat(["0xef0100", await rejecting.getAddress()])
+    );
+
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        auth.validAfter,
+        auth.validBefore,
+        auth.nonce,
+        auth.packed
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    expect(await sidecar.authorizationState(payer.address, auth.nonce)).to.equal(
+      false
+    );
+
+    await sidecar[
+      "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+    ](
+      payer.address,
+      payee.address,
+      value,
+      auth.validAfter,
+      auth.validBefore,
+      auth.nonce,
+      auth.parsed.v,
+      auth.parsed.r,
+      auth.parsed.s
+    );
+    expect(await sidecar.authorizationState(payer.address, auth.nonce)).to.equal(
+      true
+    );
+  });
+
+  it("does not let an always-valid 1271 wallet spend another account", async () => {
+    const { payer, payee, frankencoin, sidecar } = await loadFixture(deployV2);
+    const evil = await ethers.deployContract("TestAlwaysValidWallet");
+    const value = ethers.parseEther("1");
+    const nonce = ethers.randomBytes(32);
+    const validAfter = 0n;
+    const validBefore = BigInt((await time.latest()) + 3600);
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        validAfter,
+        validBefore,
+        nonce,
+        "0x1234"
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    // A wallet whose own ERC-1271 policy accepts everything can only ever authorize its own
+    // balance, so this stops at the token's balance check rather than at signature validation.
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        await evil.getAddress(),
+        payee.address,
+        value,
+        validAfter,
+        validBefore,
+        nonce,
+        "0x1234"
+      )
+    )
+      .to.be.revertedWithCustomError(frankencoin, "ERC20InsufficientBalance")
+      .withArgs(await evil.getAddress(), 0n, value);
+  });
+
+  it("rejects zero-address malformed signatures for transfer, receive, and cancel on both paths", async () => {
+    const { payee, sidecar } = await loadFixture(deployV2);
+    const nonce = ethers.randomBytes(32);
+    const validBefore = BigInt((await time.latest()) + 3600);
+    const zeroWord = ethers.ZeroHash;
+    const malformed = "0x" + "00".repeat(65);
+
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+      ](
+        ethers.ZeroAddress,
+        payee.address,
+        0n,
+        0n,
+        validBefore,
+        nonce,
+        27,
+        zeroWord,
+        zeroWord
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        ethers.ZeroAddress,
+        payee.address,
+        0n,
+        0n,
+        validBefore,
+        nonce,
+        malformed
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    await expect(
+      sidecar
+        .connect(payee)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+        ](
+          ethers.ZeroAddress,
+          payee.address,
+          0n,
+          0n,
+          validBefore,
+          nonce,
+          27,
+          zeroWord,
+          zeroWord
+        )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    await expect(
+      sidecar
+        .connect(payee)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+        ](
+          ethers.ZeroAddress,
+          payee.address,
+          0n,
+          0n,
+          validBefore,
+          nonce,
+          malformed
+        )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    await expect(
+      sidecar["cancelAuthorization(address,bytes32,uint8,bytes32,bytes32)"](
+        ethers.ZeroAddress,
+        nonce,
+        27,
+        zeroWord,
+        zeroWord
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    await expect(
+      sidecar["cancelAuthorization(address,bytes32,bytes)"](
+        ethers.ZeroAddress,
+        nonce,
+        malformed
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    expect(
+      await sidecar.authorizationState(ethers.ZeroAddress, nonce)
+    ).to.equal(false);
+  });
+
+  it("rejects malleable high-s signatures for transfer, receive, and cancel on both paths", async () => {
+    const { payer, payee, sidecar } = await loadFixture(deployV2);
+    const value = ethers.parseEther("1");
+    const auth = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value
+    );
+    const flipped = malleate(auth.signature);
+
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        auth.validAfter,
+        auth.validBefore,
+        auth.nonce,
+        flipped.v,
+        flipped.r,
+        flipped.s
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        auth.validAfter,
+        auth.validBefore,
+        auth.nonce,
+        ethers.concat([flipped.r, flipped.s, ethers.toBeHex(flipped.v, 1)])
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    expect(await sidecar.authorizationState(payer.address, auth.nonce)).to.equal(
+      false
+    );
+
+    const receiveNonce = ethers.randomBytes(32);
+    const receiveSignature = await payer.signTypedData(
+      await domainFor(await sidecar.getAddress()),
+      receiveTypes,
+      {
+        from: payer.address,
+        to: payee.address,
+        value,
+        validAfter: 0n,
+        validBefore: auth.validBefore,
+        nonce: receiveNonce,
+      }
+    );
+    const flippedReceive = malleate(receiveSignature);
+    await expect(
+      sidecar
+        .connect(payee)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+        ](
+          payer.address,
+          payee.address,
+          value,
+          0n,
+          auth.validBefore,
+          receiveNonce,
+          flippedReceive.v,
+          flippedReceive.r,
+          flippedReceive.s
+        )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    await expect(
+      sidecar
+        .connect(payee)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+        ](
+          payer.address,
+          payee.address,
+          value,
+          0n,
+          auth.validBefore,
+          receiveNonce,
+          ethers.concat([
+            flippedReceive.r,
+            flippedReceive.s,
+            ethers.toBeHex(flippedReceive.v, 1),
+          ])
+        )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    expect(
+      await sidecar.authorizationState(payer.address, receiveNonce)
+    ).to.equal(false);
+
+    const cancelNonce = ethers.randomBytes(32);
+    const cancelSignature = await payer.signTypedData(
+      await domainFor(await sidecar.getAddress()),
+      cancelTypes,
+      { authorizer: payer.address, nonce: cancelNonce }
+    );
+    const flippedCancel = malleate(cancelSignature);
+    await expect(
+      sidecar["cancelAuthorization(address,bytes32,uint8,bytes32,bytes32)"](
+        payer.address,
+        cancelNonce,
+        flippedCancel.v,
+        flippedCancel.r,
+        flippedCancel.s
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    await expect(
+      sidecar["cancelAuthorization(address,bytes32,bytes)"](
+        payer.address,
+        cancelNonce,
+        ethers.concat([
+          flippedCancel.r,
+          flippedCancel.s,
+          ethers.toBeHex(flippedCancel.v, 1),
+        ])
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    expect(
+      await sidecar.authorizationState(payer.address, cancelNonce)
+    ).to.equal(false);
+  });
+
+  it("rejects malformed encodings and v outside {27, 28} for every authorization operation", async () => {
+    const { payer, payee, sidecar } = await loadFixture(deployV2);
+    const value = ethers.parseEther("1");
+    const auth = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value
+    );
+    const legacyV = auth.parsed.v - 27; // 0 or 1, as some libraries still emit
+
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        auth.validAfter,
+        auth.validBefore,
+        auth.nonce,
+        legacyV,
+        auth.parsed.r,
+        auth.parsed.s
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        auth.validAfter,
+        auth.validBefore,
+        auth.nonce,
+        ethers.concat([
+          auth.parsed.r,
+          auth.parsed.s,
+          ethers.toBeHex(legacyV, 1),
+        ])
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    for (const length of [0, 64, 66]) {
+      const malformedNonce = ethers.randomBytes(32);
+      await expect(
+        sidecar[
+          "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+        ](
+          payer.address,
+          payee.address,
+          value,
+          auth.validAfter,
+          auth.validBefore,
+          malformedNonce,
+          ethers.hexlify(ethers.randomBytes(length))
+        )
+      ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+      expect(
+        await sidecar.authorizationState(payer.address, malformedNonce)
+      ).to.equal(false);
+    }
+
+    const receiveNonce = ethers.randomBytes(32);
+    const receiveSignature = ethers.Signature.from(
+      await payer.signTypedData(
+        await domainFor(await sidecar.getAddress()),
+        receiveTypes,
+        {
+          from: payer.address,
+          to: payee.address,
+          value,
+          validAfter: 0n,
+          validBefore: auth.validBefore,
+          nonce: receiveNonce,
+        }
+      )
+    );
+    const receiveLegacyV = receiveSignature.v - 27;
+    await expect(
+      sidecar
+        .connect(payee)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+        ](
+          payer.address,
+          payee.address,
+          value,
+          0n,
+          auth.validBefore,
+          receiveNonce,
+          receiveLegacyV,
+          receiveSignature.r,
+          receiveSignature.s
+        )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    await expect(
+      sidecar
+        .connect(payee)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+        ](
+          payer.address,
+          payee.address,
+          value,
+          0n,
+          auth.validBefore,
+          receiveNonce,
+          ethers.concat([
+            receiveSignature.r,
+            receiveSignature.s,
+            ethers.toBeHex(receiveLegacyV, 1),
+          ])
+        )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    expect(
+      await sidecar.authorizationState(payer.address, receiveNonce)
+    ).to.equal(false);
+
+    const cancelNonce = ethers.randomBytes(32);
+    const cancelSignature = ethers.Signature.from(
+      await payer.signTypedData(
+        await domainFor(await sidecar.getAddress()),
+        cancelTypes,
+        { authorizer: payer.address, nonce: cancelNonce }
+      )
+    );
+    const cancelLegacyV = cancelSignature.v - 27;
+    await expect(
+      sidecar["cancelAuthorization(address,bytes32,uint8,bytes32,bytes32)"](
+        payer.address,
+        cancelNonce,
+        cancelLegacyV,
+        cancelSignature.r,
+        cancelSignature.s
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    await expect(
+      sidecar["cancelAuthorization(address,bytes32,bytes)"](
+        payer.address,
+        cancelNonce,
+        ethers.concat([
+          cancelSignature.r,
+          cancelSignature.s,
+          ethers.toBeHex(cancelLegacyV, 1),
+        ])
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    expect(
+      await sidecar.authorizationState(payer.address, cancelNonce)
+    ).to.equal(false);
+  });
+
+  it("matches the off-chain EIP-712 domain separator", async () => {
+    const { sidecar } = await loadFixture(deployV2);
+    const domain = await domainFor(await sidecar.getAddress());
+    expect(await sidecar.DOMAIN_SEPARATOR()).to.equal(
+      ethers.TypedDataEncoder.hashDomain(domain)
+    );
+  });
+
+  it("executes receiveWithAuthorization via the v,r,s overload", async () => {
+    const { payer, payee, frankencoin, sidecar } = await loadFixture(deployV2);
+    const value = ethers.parseEther("2");
+    const nonce = ethers.randomBytes(32);
+    const validBefore = BigInt((await time.latest()) + 3600);
+    const signature = await payer.signTypedData(
+      await domainFor(await sidecar.getAddress()),
+      receiveTypes,
+      {
+        from: payer.address,
+        to: payee.address,
+        value,
+        validAfter: 0n,
+        validBefore,
+        nonce,
+      }
+    );
+    const parsed = ethers.Signature.from(signature);
+
+    await expect(
+      sidecar
+        .connect(payer)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+        ](
+          payer.address,
+          payee.address,
+          value,
+          0n,
+          validBefore,
+          nonce,
+          parsed.v,
+          parsed.r,
+          parsed.s
+        )
+    ).to.be.revertedWithCustomError(sidecar, "CallerMustBePayee");
+
+    await expect(
+      sidecar
+        .connect(payee)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+        ](
+          payer.address,
+          payee.address,
+          value,
+          0n,
+          validBefore,
+          nonce,
+          parsed.v,
+          parsed.r,
+          parsed.s
+        )
+    ).to.changeTokenBalances(frankencoin, [payer, payee], [-value, value]);
+  });
+
+  it("cancels via the classic v,r,s overload", async () => {
+    const { payer, sidecar } = await loadFixture(deployV2);
+    const nonce = ethers.randomBytes(32);
+    const signature = await payer.signTypedData(
+      await domainFor(await sidecar.getAddress()),
+      cancelTypes,
+      { authorizer: payer.address, nonce }
+    );
+    const parsed = ethers.Signature.from(signature);
+
+    await expect(
+      sidecar["cancelAuthorization(address,bytes32,uint8,bytes32,bytes32)"](
+        payer.address,
+        nonce,
+        parsed.v,
+        parsed.r,
+        parsed.s
+      )
+    )
+      .to.emit(sidecar, "AuthorizationCanceled")
+      .withArgs(payer.address, ethers.hexlify(nonce));
+    expect(await sidecar.authorizationState(payer.address, nonce)).to.equal(
+      true
+    );
+
+    // Cancelling twice must not be possible, on either overload.
+    await expect(
+      sidecar["cancelAuthorization(address,bytes32,uint8,bytes32,bytes32)"](
+        payer.address,
+        nonce,
+        parsed.v,
+        parsed.r,
+        parsed.s
+      )
+    ).to.be.revertedWithCustomError(sidecar, "AuthorizationAlreadyUsed");
+    await expect(
+      sidecar["cancelAuthorization(address,bytes32,bytes)"](
+        payer.address,
+        nonce,
+        packedSignature(signature)
+      )
+    ).to.be.revertedWithCustomError(sidecar, "AuthorizationAlreadyUsed");
+  });
+
+  it("rejects a contract wallet on the classic v,r,s cancel overload", async () => {
+    const { owner, sidecar } = await loadFixture(deployV2);
+    const wallet = await ethers.deployContract("TestContractWallet", [
+      owner.address,
+    ]);
+    const authorizer = await wallet.getAddress();
+    const nonce = ethers.randomBytes(32);
+    const signature = await owner.signTypedData(
+      await domainFor(await sidecar.getAddress()),
+      cancelTypes,
+      { authorizer, nonce }
+    );
+    const parsed = ethers.Signature.from(signature);
+
+    // ERC-1271 belongs to the ERC-7598 bytes overloads only.
+    await expect(
+      sidecar["cancelAuthorization(address,bytes32,uint8,bytes32,bytes32)"](
+        authorizer,
+        nonce,
+        parsed.v,
+        parsed.r,
+        parsed.s
+      )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+
+    await sidecar["cancelAuthorization(address,bytes32,bytes)"](
+      authorizer,
+      nonce,
+      packedSignature(signature)
+    );
+    expect(await sidecar.authorizationState(authorizer, nonce)).to.equal(true);
+  });
+
+  it("rejects a contract wallet on classic receive and honours it on the bytes overload", async () => {
+    const { owner, payee, frankencoin, sidecar } = await loadFixture(deployV2);
+    const wallet = await ethers.deployContract("TestContractWallet", [
+      owner.address,
+    ]);
+    const from = await wallet.getAddress();
+    await frankencoin.mint(from, ethers.parseEther("50"));
+
+    const value = ethers.parseEther("6");
+    const nonce = ethers.randomBytes(32);
+    const validBefore = BigInt((await time.latest()) + 3600);
+    const signature = await owner.signTypedData(
+      await domainFor(await sidecar.getAddress()),
+      receiveTypes,
+      { from, to: payee.address, value, validAfter: 0n, validBefore, nonce }
+    );
+    const parsed = ethers.Signature.from(signature);
+
+    await expect(
+      sidecar
+        .connect(payee)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+        ](
+          from,
+          payee.address,
+          value,
+          0n,
+          validBefore,
+          nonce,
+          parsed.v,
+          parsed.r,
+          parsed.s
+        )
+    ).to.be.revertedWithCustomError(sidecar, "InvalidSignature");
+    expect(await sidecar.authorizationState(from, nonce)).to.equal(false);
+
+    await expect(
+      sidecar
+        .connect(payee)
+        [
+          "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+        ](
+          from,
+          payee.address,
+          value,
+          0n,
+          validBefore,
+          nonce,
+          packedSignature(signature)
+        )
+    ).to.changeTokenBalances(frankencoin, [from, payee.address], [-value, value]);
+  });
+
+  it("rejects an authorization replayed across the two signature paths", async () => {
+    const { payer, payee, sidecar } = await loadFixture(deployV2);
+    const value = ethers.parseEther("1");
+
+    const viaVrs = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value
+    );
+    await sidecar[
+      "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+    ](
+      payer.address,
+      payee.address,
+      value,
+      viaVrs.validAfter,
+      viaVrs.validBefore,
+      viaVrs.nonce,
+      viaVrs.parsed.v,
+      viaVrs.parsed.r,
+      viaVrs.parsed.s
+    );
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        viaVrs.validAfter,
+        viaVrs.validBefore,
+        viaVrs.nonce,
+        viaVrs.packed
+      )
+    ).to.be.revertedWithCustomError(sidecar, "AuthorizationAlreadyUsed");
+
+    const viaBytes = await signTransfer(
+      payer,
+      await sidecar.getAddress(),
+      payee.address,
+      value
+    );
+    await sidecar[
+      "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)"
+    ](
+      payer.address,
+      payee.address,
+      value,
+      viaBytes.validAfter,
+      viaBytes.validBefore,
+      viaBytes.nonce,
+      viaBytes.packed
+    );
+    await expect(
+      sidecar[
+        "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)"
+      ](
+        payer.address,
+        payee.address,
+        value,
+        viaBytes.validAfter,
+        viaBytes.validBefore,
+        viaBytes.nonce,
+        viaBytes.parsed.v,
+        viaBytes.parsed.r,
+        viaBytes.parsed.s
+      )
+    ).to.be.revertedWithCustomError(sidecar, "AuthorizationAlreadyUsed");
+  });
+
+  it("rejects initialize from a non-deployer and a second initialize", async () => {
+    const [owner] = await ethers.getSigners();
+    const frankencoin = await ethers.deployContract("Frankencoin", [0]);
+    await frankencoin.initialize(owner.address, "");
+    const sidecar = await ethers.deployContract("TransferWithAuthorizationV2");
+    await expect(
+      sidecar.initialize(await frankencoin.getAddress())
+    ).to.be.revertedWithCustomError(sidecar, "CallerMustBeDeployer");
+
+    const initializer = await impersonateInitializer();
+    await sidecar.connect(initializer).initialize(await frankencoin.getAddress());
+    await expect(
+      sidecar.connect(initializer).initialize(await frankencoin.getAddress())
+    ).to.be.revertedWithCustomError(sidecar, "AlreadyInitialized");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `TransferWithAuthorizationV2` as a new CREATE2 sidecar (new address, separate minter). Live V1 at `0xc477...` is unchanged.
- Classic EIP-3009 `(v, r, s)` stays ECDSA-only. Additive `bytes` overloads follow FiatTokenV2_2 / xGAS: ECDSA if the signer has no code, ERC-1271 if it has code (no ECDSA fallback after 7702 delegation).
- EIP-712 domain is `{ name: "Frankencoin", version: "1", chainId, verifyingContract }`. Domain version stays `"1"`; `V2` is the implementation, not the signing domain. Name is hardcoded (not copied from the token at init). `verifyingContract` is the V2 address, so V1 signatures cannot be replayed here.

This is a draft so the change can be reviewed and extended in place. V2 is not deployed and should not be listed in `address.config.ts` until it is a minter on that chain.

To confirm the sidecar itself: `npx hardhat test test/TransferWithAuthorizationTest.ts`. V1 at `0xc477AaB50E3b641f27c4814c1906864464Ad70D5` must keep its current Sourcify bytecode. Predict the V2 CREATE2 address with a dry run of `scripts/deployTransferWithAuthorizationV2.ts`; do not treat a predicted address as live.